### PR TITLE
Fix endpoint addresses for cdc/vendor

### DIFF
--- a/src/cdcusb.h
+++ b/src/cdcusb.h
@@ -37,7 +37,8 @@ public:
     operator bool() const;
 
 
-    uint8_t _EPNUM_CDC;
+    uint8_t _EPNUM_CDC_IN;
+    uint8_t _EPNUM_CDC_OUT;
 
     friend void tud_cdc_line_coding_cb(uint8_t itf, cdc_line_coding_t const* p_line_coding);
 

--- a/src/classes/cdc/cdcusb.cpp
+++ b/src/classes/cdc/cdcusb.cpp
@@ -4,7 +4,8 @@
 
 #if CFG_TUD_CDC
 
-#define EPNUM_CDC   0x03
+#define EPNUM_CDC_IN   2
+#define EPNUM_CDC_OUT   3
 
 static CDCusb* _CDCusb[2] = {};
 enum { CDC_LINE_IDLE, CDC_LINE_1, CDC_LINE_2, CDC_LINE_3 };
@@ -14,18 +15,20 @@ CDCusb::CDCusb(uint8_t itf)
     _itf = itf;
     _CDCusb[_itf] = this;
     enableCDC = true;
-    _EPNUM_CDC = EPNUM_CDC;
+    _EPNUM_CDC_IN = EPNUM_CDC_IN;
+    _EPNUM_CDC_OUT = EPNUM_CDC_OUT;
 }
 
 void CDCusb::setBaseEP(uint8_t ep)
 {
-  _EPNUM_CDC = ep;
+  _EPNUM_CDC_IN = ep;
+  _EPNUM_CDC_IN = ep + 1;
 }
 
 bool CDCusb::begin(char* str)
 {
     // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
-    uint8_t cdc[TUD_CDC_DESC_LEN] = {TUD_CDC_DESCRIPTOR(ifIdx, 4, (uint8_t)(0x80 | (_EPNUM_CDC + 2)), 8, (uint8_t)_EPNUM_CDC, (uint8_t)(0x81 + _EPNUM_CDC), 64)};
+    uint8_t cdc[TUD_CDC_DESC_LEN] = {TUD_CDC_DESCRIPTOR(ifIdx, 4, 0x81, 8, _EPNUM_CDC_OUT, 0x80 | EPNUM_CDC_IN, 64)};
     memcpy(&desc_configuration[total], cdc, sizeof(cdc));
     total += sizeof(cdc);
     ifIdx += 2;

--- a/src/classes/web/webusb.cpp
+++ b/src/classes/web/webusb.cpp
@@ -12,12 +12,14 @@ WebUSB::WebUSB(uint8_t itf)
     enableVENDOR = true;
     String url = String("www.tinyusb.org/examples/webusb-serial");
     landingPageURI(url, true);
-    _EPNUM_VENDOR = EPNUM_VENDOR;
+    _EPNUM_VENDOR_IN = EPNUM_VENDOR_IN;
+    _EPNUM_VENDOR_OUT = EPNUM_VENDOR_OUT;
 }
 
 void WebUSB::setBaseEP(uint8_t ep)
 {
-  _EPNUM_VENDOR = ep;
+  _EPNUM_VENDOR_IN = ep;
+  _EPNUM_VENDOR_OUT = ep + 1;
 }
 
 bool WebUSB::begin(char* str, const char *url, bool ssl)
@@ -26,7 +28,7 @@ bool WebUSB::begin(char* str, const char *url, bool ssl)
         landingPageURI(url, ssl);
 
     // Interface number, string index, EP Out & IN address, EP size
-    uint8_t vendor[] = {TUD_VENDOR_DESCRIPTOR(ifIdx++, 7, _EPNUM_VENDOR, (uint8_t)(0x80 | _EPNUM_VENDOR), 64)};
+    uint8_t vendor[] = {TUD_VENDOR_DESCRIPTOR(ifIdx++, 7, _EPNUM_VENDOR_OUT, (uint8_t)(0x80 | _EPNUM_VENDOR_IN), 64)};
     memcpy(&desc_configuration[total], vendor, sizeof(vendor));
     total += sizeof(vendor);
     count++;

--- a/src/webusb.h
+++ b/src/webusb.h
@@ -1,7 +1,8 @@
 #pragma once
 #include "esptinyusb.h"
 #define MS_OS_20_DESC_LEN 0xB2
-#define EPNUM_VENDOR 0x03
+#define EPNUM_VENDOR_IN  4
+#define EPNUM_VENDOR_OUT 5
 #define _vendor  "Vendor class (webUSB)"
 #if CFG_TUD_VENDOR
 
@@ -84,7 +85,8 @@ private:
   friend bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request);
 
   uint8_t* _url;
-  uint8_t _EPNUM_VENDOR;
+  uint8_t _EPNUM_VENDOR_IN;
+  uint8_t _EPNUM_VENDOR_OUT;
 
 };
 


### PR DESCRIPTION
Hello,

when using cdc & webusb at the same time, the default endpoint addresses actually clash (you can see it in the kernel logs), so it seems to me it would be nice that either the defaults are set so that they don't OR there's a line in the README indicating that they need to be overrridden if used together.

In the PR is what I used to un-clash my addresses, mostly copied from tinyusb own example at: https://github.com/hathach/tinyusb/blob/master/examples/device/webusb_serial/src/usb_descriptors.c