### PR TITLE
Fix modifier in usbkeyboard

### DIFF
--- a/src/device/hid/hidkeyboard.cpp
+++ b/src/device/hid/hidkeyboard.cpp
@@ -48,7 +48,7 @@ bool HIDkeyboard::sendPress(uint8_t _keycode, uint8_t modifier)
   uint8_t keycode[6] = {0};
   keycode[0] = _keycode;
 
-  return tud_hid_keyboard_report(report_id, keymap[_keycode].modifier, keycode);
+  return tud_hid_keyboard_report(report_id, modifier, keycode);
 }
 
 bool HIDkeyboard::sendRelease()


### PR DESCRIPTION
We already have the modifier, trying to get it again grabs the wrong information from the keymap and sends weird events.

Before the fix, `12345678` would be sent as `123$%^&*`, and none of the uppercase letters would work. This fixes this issue. 