### PR TITLE
Update usb_host_client_config_t struct

### DIFF
--- a/src/host/common/usb_host.cpp
+++ b/src/host/common/usb_host.cpp
@@ -63,9 +63,12 @@ bool USBhost::init(bool create_tasks)
     ESP_LOGI("", "install status: %d", err);
 
     const usb_host_client_config_t client_config = {
-        .client_event_callback = _client_event_callback,
-        .callback_arg = this,
-        .max_num_event_msg = 5};
+        .max_num_event_msg = 5,
+        .async = {
+            .client_event_callback = _client_event_callback,
+            .callback_arg = NULL
+        }
+    };
 
     err = usb_host_client_register(&client_config, &client_hdl);
     ESP_LOGI("", "client register status: %d", err);


### PR DESCRIPTION
In Arduino-ESP32, [IDF release/v4.4 #5911](https://github.com/espressif/arduino-esp32/pull/5911) the structure of usb_host_client_config_t changed. This change fix the client_config to be able to compile with ESP-IDF v4.4 on latest Arduino-ESP32 release.