### PR TITLE
Fix the error of crashing when sending multiple characters via cdc

### DIFF
--- a/src/device/cdc/cdcusb.cpp
+++ b/src/device/cdc/cdcusb.cpp
@@ -102,10 +102,10 @@ size_t CDCusb::write(const uint8_t *buffer, size_t size)
 {
     if (tud_cdc_n_connected(_itf))
     {
-        uint32_t d = 0;
+        size_t d = 0;
         do{
-            d += tud_cdc_n_write(_itf, buffer + d, size <= 64 ? size: size - d);
-        }while(size - d > 0 || d == 0);
+            d += tud_cdc_n_write(_itf, buffer + d, size - d <= 64 ? size - d : 64);
+        }while(size > d);
         tud_cdc_n_write_flush(_itf);
         return d;
     }

--- a/src/device/msc/flashdisk.cpp
+++ b/src/device/msc/flashdisk.cpp
@@ -147,7 +147,7 @@ bool FlashUSB::begin(char* str)
     return MSCusb::begin(str);
 }
 
-bool FlashUSB::init(char* path, char* label)
+bool FlashUSB::init(const char* path, char* label)
 {
     esp_vfs_fat_mount_config_t mount_config = 
     {

--- a/src/device/msc/sdcard.cpp
+++ b/src/device/msc/sdcard.cpp
@@ -62,17 +62,19 @@ public:
     }
     int32_t onRead(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize)
     {
-        log_v("default onread");
+        log_v("default onread lba (%u) bufsize (%u)", lba, bufsize);
         (void) lun;
-        SD.readRAW((uint8_t*)buffer, lba);
+        for (int i = 0; m_parent->block_size * i < bufsize; i++)
+            SD.readRAW((uint8_t *)buffer + m_parent->block_size * i, lba + i);
 
         return bufsize;
     }
     int32_t onWrite(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize)
     {
-        log_v("default onwrite");
+        log_v("default onwrite lba (%u) bufsize (%u)", lba, bufsize);
         (void) lun;
-        SD.writeRAW((uint8_t*)buffer, lba);
+        for (int i = 0; m_parent->block_size * i < bufsize; i++)
+            SD.writeRAW((uint8_t *)buffer + m_parent->block_size * i, lba + i);
 
         return bufsize;
     }
@@ -97,7 +99,16 @@ bool SDCard2USB::initSD(uint8_t ssPin, SPIClass &spi, uint32_t frequency, const 
         Serial.println("Card Mount Failed");
         return false;
     }
+    
+    uint8_t cardType = SD.cardType();
 
+    if(cardType == CARD_NONE){
+        Serial.println("No SD card attached");
+        return false;
+    }
+
+    block_count = SD.cardSize() / block_size;
+    sdcardReady = true;
     return true;
 }
 

--- a/src/flashdisk.h
+++ b/src/flashdisk.h
@@ -12,7 +12,7 @@ class FlashUSB : public MSCusb {
 public:
     FlashUSB(bool aes = false);
     bool begin(char* str = nullptr);
-    bool init(char* path = "/fatfs",char* label = NULL);
+    bool init(const char* path = "/fatfs",char* label = NULL);
     void setCallbacks(MSCCallbacks*);
     void setCapacity(uint32_t count, uint32_t size);
     bool isReady();

--- a/src/sdusb.h
+++ b/src/sdusb.h
@@ -1,8 +1,6 @@
 #pragma once
 #include "mscusb.h"
-#include "FS.h"
 #include "SD.h"
-#include "SPI.h"
 
 #if CFG_TUD_MSC
 


### PR DESCRIPTION
Fixes the problem of buffer processing.

Correction affects the function
`size_t CDCusb::write(const uint8_t *buffer, size_t size)`

Crashes due to the use of this function are avoided. Likewise, crashing due to the use of `printf` is avoided. This function uses `CDCusb::write`. Please merge.