### PR TITLE
Add Keyboard Layouts

### DIFF
--- a/src/layouts/BE_BE/hidkeylayout.h
+++ b/src/layouts/BE_BE/hidkeylayout.h
@@ -1,0 +1,183 @@
+#pragma once
+
+enum {
+    UK_LAYOUT,
+    US_LAYOUT
+};
+
+/* Modifiers */
+enum MODIFIER_KEY {
+        KEY_CTRL = 1,
+        KEY_SHIFT = 2,
+        KEY_ALT = 4,
+};
+
+typedef struct {
+        unsigned char usage;
+        unsigned char modifier;
+} KEYMAP;
+
+#define HID_KEY_A 0x14
+#define HID_KEY_M 0x33
+#define HID_KEY_Q 0x04
+#define HID_KEY_W 0x1d
+#define HID_KEY_Z 0x1a
+
+#define KEYMAP_SIZE (152)
+const KEYMAP keymap[KEYMAP_SIZE] = {
+    {0, 0},             /* NUL */
+    {0, 0},             /* SOH */
+    {0, 0},             /* STX */
+    {0, 0},             /* ETX */
+    {0, 0},             /* EOT */
+    {0, 0},             /* ENQ */
+    {0, 0},             /* ACK */
+    {0, 0},             /* BEL */
+    {0x2a, 0},          /* BS  */  /* Keyboard Delete (Backspace) */
+    {0x2b, 0},          /* TAB */  /* Keyboard Tab */
+    {0x28, 0},          /* LF  */  /* Keyboard Return (Enter) */
+    {0, 0},             /* VT  */
+    {0, 0},             /* FF  */
+    {0, 0},             /* CR  */
+    {0, 0},             /* SO  */
+    {0, 0},             /* SI  */
+    {0, 0},             /* DEL */
+    {0, 0},             /* DC1 */
+    {0, 0},             /* DC2 */
+    {0, 0},             /* DC3 */
+    {0, 0},             /* DC4 */
+    {0, 0},             /* NAK */
+    {0, 0},             /* SYN */
+    {0, 0},             /* ETB */
+    {0, 0},             /* CAN */
+    {0, 0},             /* EM  */
+    {0, 0},             /* SUB */
+    {0, 0},             /* ESC */
+    {0, 0},             /* FS  */
+    {0, 0},             /* GS  */
+    {0, 0},             /* RS  */
+    {0, 0},             /* US  */
+    {0x2c, 0},          /*   */
+    {0x25, 0},      /* ! */
+    {0x20, 0},      /* " */
+    {0x20, 0},      /* # */
+    {0x30, 0},      /* $ */
+    {0x34, KEY_SHIFT},      /* % */
+    {0x1e, 0},      /* & */
+    {0x21, 0},          /* ' */
+    {0x22, 0},      /* ( */
+    {0x2d, 0},      /* ) */
+    {0x30, KEY_SHIFT},      /* * */
+    {0x38, KEY_SHIFT},      /* + */
+    {0x10, 0},          /* , */
+    {0x2e, 0},          /* - */
+    {0x36, KEY_SHIFT},          /* . */
+    {0x37, KEY_SHIFT},          /* / */
+    {0x27, KEY_SHIFT},          /* 0 */
+    {0x1e, KEY_SHIFT},          /* 1 */
+    {0x1f, KEY_SHIFT},          /* 2 */
+    {0x20, KEY_SHIFT},          /* 3 */
+    {0x21, KEY_SHIFT},          /* 4 */
+    {0x22, KEY_SHIFT},          /* 5 */
+    {0x23, KEY_SHIFT},          /* 6 */
+    {0x24, KEY_SHIFT},          /* 7 */
+    {0x25, KEY_SHIFT},          /* 8 */
+    {0x26, KEY_SHIFT},          /* 9 */
+    {0x37, 0},      /* : */
+    {0x36, 0},          /* ; */
+    {0x64, 0},      /* < */
+    {0x38, 0},          /* = */
+    {0x64, KEY_SHIFT},      /* > */
+    {0x10, KEY_SHIFT},      /* ? */
+    {0x27, 0},      /* @ */
+    {0x14, KEY_SHIFT},      /* A */
+    {0x05, KEY_SHIFT},      /* B */
+    {0x06, KEY_SHIFT},      /* C */
+    {0x07, KEY_SHIFT},      /* D */
+    {0x08, KEY_SHIFT},      /* E */
+    {0x09, KEY_SHIFT},      /* F */
+    {0x0a, KEY_SHIFT},      /* G */
+    {0x0b, KEY_SHIFT},      /* H */
+    {0x0c, KEY_SHIFT},      /* I */
+    {0x0d, KEY_SHIFT},      /* J */
+    {0x0e, KEY_SHIFT},      /* K */
+    {0x0f, KEY_SHIFT},      /* L */
+    {0x33, KEY_SHIFT},      /* M */
+    {0x11, KEY_SHIFT},      /* N */
+    {0x12, KEY_SHIFT},      /* O */
+    {0x13, KEY_SHIFT},      /* P */
+    {0x04, KEY_SHIFT},      /* Q */
+    {0x15, KEY_SHIFT},      /* R */
+    {0x16, KEY_SHIFT},      /* S */
+    {0x17, KEY_SHIFT},      /* T */
+    {0x18, KEY_SHIFT},      /* U */
+    {0x19, KEY_SHIFT},      /* V */
+    {0x1d, KEY_SHIFT},      /* W */
+    {0x1b, KEY_SHIFT},      /* X */
+    {0x1c, KEY_SHIFT},      /* Y */
+    {0x1a, KEY_SHIFT},      /* Z */
+    {0x22, 0},          /* [ */
+    {0x64, 0},          /* \ */
+    {0x30, 0},          /* ] */
+    {0x22, 0},      /* ^ */
+    {0x2e, KEY_SHIFT},      /* _ */
+    {0x24, 0},          /* ` */
+    {0x14, 0},      /* a */
+    {0x05, 0},      /* b */
+    {0x06, 0},      /* c */
+    {0x07, 0},      /* d */
+    {0x08, 0},      /* e */
+    {0x09, 0},      /* f */
+    {0x0a, 0},      /* g */
+    {0x0b, 0},      /* h */
+    {0x0c, 0},      /* i */
+    {0x0d, 0},      /* j */
+    {0x0e, 0},      /* k */
+    {0x0f, 0},      /* l */
+    {0x33, 0},      /* m */
+    {0x11, 0},      /* n */
+    {0x12, 0},      /* o */
+    {0x13, 0},      /* p */
+    {0x04, 0},      /* q */
+    {0x15, 0},      /* r */
+    {0x16, 0},      /* s */
+    {0x17, 0},      /* t */
+    {0x18, 0},      /* u */
+    {0x19, 0},      /* v */
+    {0x1d, 0},      /* w */
+    {0x1b, 0},      /* x */
+    {0x1c, 0},      /* y */
+    {0x1a, 0},      /* z */
+    {0x21, 0},      /* { */
+    {0x1e, 0},      /* | */
+    {0x27, 0},      /* } */
+    {0x38, 0},      /* ~ */
+    {0,0},              /* DEL */
+
+    {0x3a, 0},          /* F1 */
+    {0x3b, 0},          /* F2 */
+    {0x3c, 0},          /* F3 */
+    {0x3d, 0},          /* F4 */
+    {0x3e, 0},          /* F5 */
+    {0x3f, 0},          /* F6 */
+    {0x40, 0},          /* F7 */
+    {0x41, 0},          /* F8 */
+    {0x42, 0},          /* F9 */
+    {0x43, 0},          /* F10 */
+    {0x44, 0},          /* F11 */
+    {0x45, 0},          /* F12 */
+
+    {0x46, 0},          /* PRINT_SCREEN */
+    {0x47, 0},          /* SCROLL_LOCK */
+    {0x39, 0},          /* CAPS_LOCK */
+    {0x53, 0},          /* NUM_LOCK */
+    {0x49, 0},          /* INSERT */
+    {0x4a, 0},          /* HOME */
+    {0x4b, 0},          /* PAGE_UP */
+    {0x4e, 0},          /* PAGE_DOWN */
+
+    {0x4f, 0},          /* RIGHT_ARROW */
+    {0x50, 0},          /* LEFT_ARROW */
+    {0x51, 0},          /* DOWN_ARROW */
+    {0x52, 0},          /* UP_ARROW */
+};

--- a/src/layouts/DA_DK/hidkeylayout.h
+++ b/src/layouts/DA_DK/hidkeylayout.h
@@ -1,0 +1,177 @@
+#pragma once
+
+enum {
+    UK_LAYOUT,
+    US_LAYOUT
+};
+
+/* Modifiers */
+enum MODIFIER_KEY {
+        KEY_CTRL = 1,
+        KEY_SHIFT = 2,
+        KEY_ALT = 4,
+};
+
+typedef struct {
+        unsigned char usage;
+        unsigned char modifier;
+} KEYMAP;
+
+#define KEYMAP_SIZE (152)
+const KEYMAP keymap[KEYMAP_SIZE] = {
+    {0, 0},             /* NUL */
+    {0, 0},             /* SOH */
+    {0, 0},             /* STX */
+    {0, 0},             /* ETX */
+    {0, 0},             /* EOT */
+    {0, 0},             /* ENQ */
+    {0, 0},             /* ACK */
+    {0, 0},             /* BEL */
+    {0x2a, 0},          /* BS  */  /* Keyboard Delete (Backspace) */
+    {0x2b, 0},          /* TAB */  /* Keyboard Tab */
+    {0x28, 0},          /* LF  */  /* Keyboard Return (Enter) */
+    {0, 0},             /* VT  */
+    {0, 0},             /* FF  */
+    {0, 0},             /* CR  */
+    {0, 0},             /* SO  */
+    {0, 0},             /* SI  */
+    {0, 0},             /* DEL */
+    {0, 0},             /* DC1 */
+    {0, 0},             /* DC2 */
+    {0, 0},             /* DC3 */
+    {0, 0},             /* DC4 */
+    {0, 0},             /* NAK */
+    {0, 0},             /* SYN */
+    {0, 0},             /* ETB */
+    {0, 0},             /* CAN */
+    {0, 0},             /* EM  */
+    {0, 0},             /* SUB */
+    {0, 0},             /* ESC */
+    {0, 0},             /* FS  */
+    {0, 0},             /* GS  */
+    {0, 0},             /* RS  */
+    {0, 0},             /* US  */
+    {0x2c, 0},          /*   */
+    {0x1e, KEY_SHIFT},      /* ! */
+    {0x1f, KEY_SHIFT},      /* " */
+    {0x20, KEY_SHIFT},      /* # */
+    {0x21, 0},      /* $ */
+    {0x22, KEY_SHIFT},      /* % */
+    {0x23, KEY_SHIFT},      /* & */
+    {0x31, 0},          /* ' */
+    {0x25, KEY_SHIFT},      /* ( */
+    {0x26, KEY_SHIFT},      /* ) */
+    {0x31, KEY_SHIFT},      /* * */
+    {0x2d, 0},      /* + */
+    {0x36, 0},          /* , */
+    {0x38, 0},          /* - */
+    {0x37, 0},          /* . */
+    {0x24, KEY_SHIFT},          /* / */
+    {0x27, 0},          /* 0 */
+    {0x1e, 0},          /* 1 */
+    {0x1f, 0},          /* 2 */
+    {0x20, 0},          /* 3 */
+    {0x21, 0},          /* 4 */
+    {0x22, 0},          /* 5 */
+    {0x23, 0},          /* 6 */
+    {0x24, 0},          /* 7 */
+    {0x25, 0},          /* 8 */
+    {0x26, 0},          /* 9 */
+    {0x37, KEY_SHIFT},      /* : */
+    {0x36, KEY_SHIFT},          /* ; */
+    {0x64, 0},      /* < */
+    {0x27, KEY_SHIFT},          /* = */
+    {0x64, KEY_SHIFT},      /* > */
+    {0x2d, KEY_SHIFT},      /* ? */
+    {0x1f, 0},      /* @ */
+    {0x04, KEY_SHIFT},      /* A */
+    {0x05, KEY_SHIFT},      /* B */
+    {0x06, KEY_SHIFT},      /* C */
+    {0x07, KEY_SHIFT},      /* D */
+    {0x08, KEY_SHIFT},      /* E */
+    {0x09, KEY_SHIFT},      /* F */
+    {0x0a, KEY_SHIFT},      /* G */
+    {0x0b, KEY_SHIFT},      /* H */
+    {0x0c, KEY_SHIFT},      /* I */
+    {0x0d, KEY_SHIFT},      /* J */
+    {0x0e, KEY_SHIFT},      /* K */
+    {0x0f, KEY_SHIFT},      /* L */
+    {0x10, KEY_SHIFT},      /* M */
+    {0x11, KEY_SHIFT},      /* N */
+    {0x12, KEY_SHIFT},      /* O */
+    {0x13, KEY_SHIFT},      /* P */
+    {0x14, KEY_SHIFT},      /* Q */
+    {0x15, KEY_SHIFT},      /* R */
+    {0x16, KEY_SHIFT},      /* S */
+    {0x17, KEY_SHIFT},      /* T */
+    {0x18, KEY_SHIFT},      /* U */
+    {0x19, KEY_SHIFT},      /* V */
+    {0x1a, KEY_SHIFT},      /* W */
+    {0x1b, KEY_SHIFT},      /* X */
+    {0x1c, KEY_SHIFT},      /* Y */
+    {0x1d, KEY_SHIFT},      /* Z */
+    {0x25, 0},          /* [ */
+    {0x64, 0},          /* \ */
+    {0x26, 0},          /* ] */
+    {0x30, KEY_SHIFT},      /* ^ */
+    {0x38, KEY_SHIFT},      /* _ */
+    {0x2e, KEY_SHIFT},          /* ` */
+    {0x04, 0},          /* a */
+    {0x05, 0},          /* b */
+    {0x06, 0},          /* c */
+    {0x07, 0},          /* d */
+    {0x08, 0},          /* e */
+    {0x09, 0},          /* f */
+    {0x0a, 0},          /* g */
+    {0x0b, 0},          /* h */
+    {0x0c, 0},          /* i */
+    {0x0d, 0},          /* j */
+    {0x0e, 0},          /* k */
+    {0x0f, 0},          /* l */
+    {0x10, 0},          /* m */
+    {0x11, 0},          /* n */
+    {0x12, 0},          /* o */
+    {0x13, 0},          /* p */
+    {0x14, 0},          /* q */
+    {0x15, 0},          /* r */
+    {0x16, 0},          /* s */
+    {0x17, 0},          /* t */
+    {0x18, 0},          /* u */
+    {0x19, 0},          /* v */
+    {0x1a, 0},          /* w */
+    {0x1b, 0},          /* x */
+    {0x1c, 0},          /* y */
+    {0x1d, 0},          /* z */
+    {0x24, 0},      /* { */
+    {0x2e, 0},      /* | */
+    {0x27, 0},      /* } */
+    {0x30, 0},      /* ~ */
+    {0,0},              /* DEL */
+
+    {0x3a, 0},          /* F1 */
+    {0x3b, 0},          /* F2 */
+    {0x3c, 0},          /* F3 */
+    {0x3d, 0},          /* F4 */
+    {0x3e, 0},          /* F5 */
+    {0x3f, 0},          /* F6 */
+    {0x40, 0},          /* F7 */
+    {0x41, 0},          /* F8 */
+    {0x42, 0},          /* F9 */
+    {0x43, 0},          /* F10 */
+    {0x44, 0},          /* F11 */
+    {0x45, 0},          /* F12 */
+
+    {0x46, 0},          /* PRINT_SCREEN */
+    {0x47, 0},          /* SCROLL_LOCK */
+    {0x39, 0},          /* CAPS_LOCK */
+    {0x53, 0},          /* NUM_LOCK */
+    {0x49, 0},          /* INSERT */
+    {0x4a, 0},          /* HOME */
+    {0x4b, 0},          /* PAGE_UP */
+    {0x4e, 0},          /* PAGE_DOWN */
+
+    {0x4f, 0},          /* RIGHT_ARROW */
+    {0x50, 0},          /* LEFT_ARROW */
+    {0x51, 0},          /* DOWN_ARROW */
+    {0x52, 0},          /* UP_ARROW */
+};

--- a/src/layouts/DE_DE/hidkeylayout.h
+++ b/src/layouts/DE_DE/hidkeylayout.h
@@ -1,0 +1,177 @@
+#pragma once
+
+enum {
+    UK_LAYOUT,
+    US_LAYOUT
+};
+
+/* Modifiers */
+enum MODIFIER_KEY {
+        KEY_CTRL = 1,
+        KEY_SHIFT = 2,
+        KEY_ALT = 4,
+};
+
+typedef struct {
+        unsigned char usage;
+        unsigned char modifier;
+} KEYMAP;
+
+#define KEYMAP_SIZE (152)
+const KEYMAP keymap[KEYMAP_SIZE] = {
+    {0, 0},             /* NUL */
+    {0, 0},             /* SOH */
+    {0, 0},             /* STX */
+    {0, 0},             /* ETX */
+    {0, 0},             /* EOT */
+    {0, 0},             /* ENQ */
+    {0, 0},             /* ACK */
+    {0, 0},             /* BEL */
+    {0x2a, 0},          /* BS  */  /* Keyboard Delete (Backspace) */
+    {0x2b, 0},          /* TAB */  /* Keyboard Tab */
+    {0x28, 0},          /* LF  */  /* Keyboard Return (Enter) */
+    {0, 0},             /* VT  */
+    {0, 0},             /* FF  */
+    {0, 0},             /* CR  */
+    {0, 0},             /* SO  */
+    {0, 0},             /* SI  */
+    {0, 0},             /* DEL */
+    {0, 0},             /* DC1 */
+    {0, 0},             /* DC2 */
+    {0, 0},             /* DC3 */
+    {0, 0},             /* DC4 */
+    {0, 0},             /* NAK */
+    {0, 0},             /* SYN */
+    {0, 0},             /* ETB */
+    {0, 0},             /* CAN */
+    {0, 0},             /* EM  */
+    {0, 0},             /* SUB */
+    {0, 0},             /* ESC */
+    {0, 0},             /* FS  */
+    {0, 0},             /* GS  */
+    {0, 0},             /* RS  */
+    {0, 0},             /* US  */
+    {0x2c, 0},          /*   */
+    {0x1e, KEY_SHIFT},      /* ! */
+    {0x1f, KEY_SHIFT},      /* " */
+    {0x31, 0},      /* # */
+    {0x21, KEY_SHIFT},      /* $ */
+    {0x22, KEY_SHIFT},      /* % */
+    {0x23, KEY_SHIFT},      /* & */
+    {0x31, KEY_SHIFT},          /* ' */
+    {0x25, KEY_SHIFT},      /* ( */
+    {0x26, KEY_SHIFT},      /* ) */
+    {0x30, KEY_SHIFT},      /* * */
+    {0x30, 0},      /* + */
+    {0x36, 0},          /* , */
+    {0x38, 0},          /* - */
+    {0x37, 0},          /* . */
+    {0x24, KEY_SHIFT},          /* / */
+    {0x27, 0},          /* 0 */
+    {0x1e, 0},          /* 1 */
+    {0x1f, 0},          /* 2 */
+    {0x20, 0},          /* 3 */
+    {0x21, 0},          /* 4 */
+    {0x22, 0},          /* 5 */
+    {0x23, 0},          /* 6 */
+    {0x24, 0},          /* 7 */
+    {0x25, 0},          /* 8 */
+    {0x26, 0},          /* 9 */
+    {0x37, KEY_SHIFT},      /* : */
+    {0x36, KEY_SHIFT},          /* ; */
+    {0x64, 0},      /* < */
+    {0x27, KEY_SHIFT},          /* = */
+    {0x64, KEY_SHIFT},      /* > */
+    {0x2d, KEY_SHIFT},      /* ? */
+    {0x14, 0},      /* @ */
+    {0x04, KEY_SHIFT},      /* A */
+    {0x05, KEY_SHIFT},      /* B */
+    {0x06, KEY_SHIFT},      /* C */
+    {0x07, KEY_SHIFT},      /* D */
+    {0x08, KEY_SHIFT},      /* E */
+    {0x09, KEY_SHIFT},      /* F */
+    {0x0a, KEY_SHIFT},      /* G */
+    {0x0b, KEY_SHIFT},      /* H */
+    {0x0c, KEY_SHIFT},      /* I */
+    {0x0d, KEY_SHIFT},      /* J */
+    {0x0e, KEY_SHIFT},      /* K */
+    {0x0f, KEY_SHIFT},      /* L */
+    {0x10, KEY_SHIFT},      /* M */
+    {0x11, KEY_SHIFT},      /* N */
+    {0x12, KEY_SHIFT},      /* O */
+    {0x13, KEY_SHIFT},      /* P */
+    {0x14, KEY_SHIFT},      /* Q */
+    {0x15, KEY_SHIFT},      /* R */
+    {0x16, KEY_SHIFT},      /* S */
+    {0x17, KEY_SHIFT},      /* T */
+    {0x18, KEY_SHIFT},      /* U */
+    {0x19, KEY_SHIFT},      /* V */
+    {0x1a, KEY_SHIFT},      /* W */
+    {0x1b, KEY_SHIFT},      /* X */
+    {0x1c, KEY_SHIFT},      /* Y */
+    {0x1d, KEY_SHIFT},      /* Z */
+    {0x25, 0},          /* [ */
+    {0x2d, 0},          /* \ */
+    {0x26, 0},          /* ] */
+    {0x35, 0},      /* ^ */
+    {0x38, KEY_SHIFT},      /* _ */
+    {0x2e, KEY_SHIFT},          /* ` */
+    {0x04, 0},          /* a */
+    {0x05, 0},          /* b */
+    {0x06, 0},          /* c */
+    {0x07, 0},          /* d */
+    {0x08, 0},          /* e */
+    {0x09, 0},          /* f */
+    {0x0a, 0},          /* g */
+    {0x0b, 0},          /* h */
+    {0x0c, 0},          /* i */
+    {0x0d, 0},          /* j */
+    {0x0e, 0},          /* k */
+    {0x0f, 0},          /* l */
+    {0x10, 0},          /* m */
+    {0x11, 0},          /* n */
+    {0x12, 0},          /* o */
+    {0x13, 0},          /* p */
+    {0x14, 0},          /* q */
+    {0x15, 0},          /* r */
+    {0x16, 0},          /* s */
+    {0x17, 0},          /* t */
+    {0x18, 0},          /* u */
+    {0x19, 0},          /* v */
+    {0x1a, 0},          /* w */
+    {0x1b, 0},          /* x */
+    {0, 0},          /* y */
+    {0x1c, 0},          /* z */
+    {0x24, 0},      /* { */
+    {0x64, 0},      /* | */
+    {0x27, 0},      /* } */
+    {0x30, 0},      /* ~ */
+    {0,0},              /* DEL */
+
+    {0x3a, 0},          /* F1 */
+    {0x3b, 0},          /* F2 */
+    {0x3c, 0},          /* F3 */
+    {0x3d, 0},          /* F4 */
+    {0x3e, 0},          /* F5 */
+    {0x3f, 0},          /* F6 */
+    {0x40, 0},          /* F7 */
+    {0x41, 0},          /* F8 */
+    {0x42, 0},          /* F9 */
+    {0x43, 0},          /* F10 */
+    {0x44, 0},          /* F11 */
+    {0x45, 0},          /* F12 */
+
+    {0x46, 0},          /* PRINT_SCREEN */
+    {0x47, 0},          /* SCROLL_LOCK */
+    {0x39, 0},          /* CAPS_LOCK */
+    {0x53, 0},          /* NUM_LOCK */
+    {0x49, 0},          /* INSERT */
+    {0x4a, 0},          /* HOME */
+    {0x4b, 0},          /* PAGE_UP */
+    {0x4e, 0},          /* PAGE_DOWN */
+
+    {0x4f, 0},          /* RIGHT_ARROW */
+    {0x50, 0},          /* LEFT_ARROW */
+    {0x51, 0},          /* DOWN_ARROW */
+    {0x52, 0},          /* UP_ARROW */
+};

--- a/src/layouts/EN_UK/hidkeylayout.h
+++ b/src/layouts/EN_UK/hidkeylayout.h
@@ -1,0 +1,177 @@
+#pragma once
+
+enum {
+    UK_LAYOUT,
+    US_LAYOUT
+};
+
+/* Modifiers */
+enum MODIFIER_KEY {
+        KEY_CTRL = 1,
+        KEY_SHIFT = 2,
+        KEY_ALT = 4,
+};
+
+typedef struct {
+        unsigned char usage;
+        unsigned char modifier;
+} KEYMAP;
+
+#define KEYMAP_SIZE (152)
+const KEYMAP keymap[KEYMAP_SIZE] = {
+    {0, 0},             /* NUL */
+    {0, 0},             /* SOH */
+    {0, 0},             /* STX */
+    {0, 0},             /* ETX */
+    {0, 0},             /* EOT */
+    {0, 0},             /* ENQ */
+    {0, 0},             /* ACK */
+    {0, 0},             /* BEL */
+    {0x2a, 0},          /* BS  */  /* Keyboard Delete (Backspace) */
+    {0x2b, 0},          /* TAB */  /* Keyboard Tab */
+    {0x28, 0},          /* LF  */  /* Keyboard Return (Enter) */
+    {0, 0},             /* VT  */
+    {0, 0},             /* FF  */
+    {0, 0},             /* CR  */
+    {0, 0},             /* SO  */
+    {0, 0},             /* SI  */
+    {0, 0},             /* DEL */
+    {0, 0},             /* DC1 */
+    {0, 0},             /* DC2 */
+    {0, 0},             /* DC3 */
+    {0, 0},             /* DC4 */
+    {0, 0},             /* NAK */
+    {0, 0},             /* SYN */
+    {0, 0},             /* ETB */
+    {0, 0},             /* CAN */
+    {0, 0},             /* EM  */
+    {0, 0},             /* SUB */
+    {0, 0},             /* ESC */
+    {0, 0},             /* FS  */
+    {0, 0},             /* GS  */
+    {0, 0},             /* RS  */
+    {0, 0},             /* US  */
+    {0x2c, 0},          /*   */
+    {0x1e, KEY_SHIFT},      /* ! */
+    {0x1f, KEY_SHIFT},      /* " */
+    {0x31, 0},      /* # */
+    {0x21, KEY_SHIFT},      /* $ */
+    {0x22, KEY_SHIFT},      /* % */
+    {0x24, KEY_SHIFT},      /* & */
+    {0x34, 0},          /* ' */
+    {0x26, KEY_SHIFT},      /* ( */
+    {0x27, KEY_SHIFT},      /* ) */
+    {0x25, KEY_SHIFT},      /* * */
+    {0x2e, KEY_SHIFT},      /* + */
+    {0x36, 0},          /* , */
+    {0x2d, 0},          /* - */
+    {0x37, 0},          /* . */
+    {0x38, 0},          /* / */
+    {0x27, 0},          /* 0 */
+    {0x1e, 0},          /* 1 */
+    {0x1f, 0},          /* 2 */
+    {0x20, 0},          /* 3 */
+    {0x21, 0},          /* 4 */
+    {0x22, 0},          /* 5 */
+    {0x23, 0},          /* 6 */
+    {0x24, 0},          /* 7 */
+    {0x25, 0},          /* 8 */
+    {0x26, 0},          /* 9 */
+    {0x33, KEY_SHIFT},      /* : */
+    {0x33, 0},          /* ; */
+    {0x36, KEY_SHIFT},      /* < */
+    {0x2e, 0},          /* = */
+    {0x37, KEY_SHIFT},      /* > */
+    {0x38, KEY_SHIFT},      /* ? */
+    {0x34, KEY_SHIFT},      /* @ */
+    {0x04, KEY_SHIFT},      /* A */
+    {0x05, KEY_SHIFT},      /* B */
+    {0x06, KEY_SHIFT},      /* C */
+    {0x07, KEY_SHIFT},      /* D */
+    {0x08, KEY_SHIFT},      /* E */
+    {0x09, KEY_SHIFT},      /* F */
+    {0x0a, KEY_SHIFT},      /* G */
+    {0x0b, KEY_SHIFT},      /* H */
+    {0x0c, KEY_SHIFT},      /* I */
+    {0x0d, KEY_SHIFT},      /* J */
+    {0x0e, KEY_SHIFT},      /* K */
+    {0x0f, KEY_SHIFT},      /* L */
+    {0x10, KEY_SHIFT},      /* M */
+    {0x11, KEY_SHIFT},      /* N */
+    {0x12, KEY_SHIFT},      /* O */
+    {0x13, KEY_SHIFT},      /* P */
+    {0x14, KEY_SHIFT},      /* Q */
+    {0x15, KEY_SHIFT},      /* R */
+    {0x16, KEY_SHIFT},      /* S */
+    {0x17, KEY_SHIFT},      /* T */
+    {0x18, KEY_SHIFT},      /* U */
+    {0x19, KEY_SHIFT},      /* V */
+    {0x1a, KEY_SHIFT},      /* W */
+    {0x1b, KEY_SHIFT},      /* X */
+    {0x1c, KEY_SHIFT},      /* Y */
+    {0x1d, KEY_SHIFT},      /* Z */
+    {0x2f, 0},          /* [ */
+    {0x64, 0},          /* \ */
+    {0x30, 0},          /* ] */
+    {0x23, KEY_SHIFT},      /* ^ */
+    {0x2d, KEY_SHIFT},      /* _ */
+    {0x35, 0},          /* ` */
+    {0x04, 0},          /* a */
+    {0x05, 0},          /* b */
+    {0x06, 0},          /* c */
+    {0x07, 0},          /* d */
+    {0x08, 0},          /* e */
+    {0x09, 0},          /* f */
+    {0x0a, 0},          /* g */
+    {0x0b, 0},          /* h */
+    {0x0c, 0},          /* i */
+    {0x0d, 0},          /* j */
+    {0x0e, 0},          /* k */
+    {0x0f, 0},          /* l */
+    {0x10, 0},          /* m */
+    {0x11, 0},          /* n */
+    {0x12, 0},          /* o */
+    {0x13, 0},          /* p */
+    {0x14, 0},          /* q */
+    {0x15, 0},          /* r */
+    {0x16, 0},          /* s */
+    {0x17, 0},          /* t */
+    {0x18, 0},          /* u */
+    {0x19, 0},          /* v */
+    {0x1a, 0},          /* w */
+    {0x1b, 0},          /* x */
+    {0x1c, 0},          /* y */
+    {0x1d, 0},          /* z */
+    {0x2f, KEY_SHIFT},      /* { */
+    {0x64, KEY_SHIFT},      /* | */
+    {0x30, KEY_SHIFT},      /* } */
+    {0x31, KEY_SHIFT},      /* ~ */
+    {0,0},              /* DEL */
+
+    {0x3a, 0},          /* F1 */
+    {0x3b, 0},          /* F2 */
+    {0x3c, 0},          /* F3 */
+    {0x3d, 0},          /* F4 */
+    {0x3e, 0},          /* F5 */
+    {0x3f, 0},          /* F6 */
+    {0x40, 0},          /* F7 */
+    {0x41, 0},          /* F8 */
+    {0x42, 0},          /* F9 */
+    {0x43, 0},          /* F10 */
+    {0x44, 0},          /* F11 */
+    {0x45, 0},          /* F12 */
+
+    {0x46, 0},          /* PRINT_SCREEN */
+    {0x47, 0},          /* SCROLL_LOCK */
+    {0x39, 0},          /* CAPS_LOCK */
+    {0x53, 0},          /* NUM_LOCK */
+    {0x49, 0},          /* INSERT */
+    {0x4a, 0},          /* HOME */
+    {0x4b, 0},          /* PAGE_UP */
+    {0x4e, 0},          /* PAGE_DOWN */
+
+    {0x4f, 0},          /* RIGHT_ARROW */
+    {0x50, 0},          /* LEFT_ARROW */
+    {0x51, 0},          /* DOWN_ARROW */
+    {0x52, 0},          /* UP_ARROW */
+};

--- a/src/layouts/EN_US/hidkeylayout.h
+++ b/src/layouts/EN_US/hidkeylayout.h
@@ -1,0 +1,177 @@
+#pragma once
+
+enum {
+    UK_LAYOUT,
+    US_LAYOUT
+};
+
+/* Modifiers */
+enum MODIFIER_KEY {
+        KEY_CTRL = 1,
+        KEY_SHIFT = 2,
+        KEY_ALT = 4,
+};
+
+typedef struct {
+        unsigned char usage;
+        unsigned char modifier;
+} KEYMAP;
+
+#define KEYMAP_SIZE (152)
+const KEYMAP keymap[KEYMAP_SIZE] = {
+    {0, 0},             /* NUL */
+    {0, 0},             /* SOH */
+    {0, 0},             /* STX */
+    {0, 0},             /* ETX */
+    {0, 0},             /* EOT */
+    {0, 0},             /* ENQ */
+    {0, 0},             /* ACK */
+    {0, 0},             /* BEL */
+    {0x2a, 0},          /* BS  */  /* Keyboard Delete (Backspace) */
+    {0x2b, 0},          /* TAB */  /* Keyboard Tab */
+    {0x28, 0},          /* LF  */  /* Keyboard Return (Enter) */
+    {0, 0},             /* VT  */
+    {0, 0},             /* FF  */
+    {0, 0},             /* CR  */
+    {0, 0},             /* SO  */
+    {0, 0},             /* SI  */
+    {0, 0},             /* DEL */
+    {0, 0},             /* DC1 */
+    {0, 0},             /* DC2 */
+    {0, 0},             /* DC3 */
+    {0, 0},             /* DC4 */
+    {0, 0},             /* NAK */
+    {0, 0},             /* SYN */
+    {0, 0},             /* ETB */
+    {0, 0},             /* CAN */
+    {0, 0},             /* EM  */
+    {0, 0},             /* SUB */
+    {0, 0},             /* ESC */
+    {0, 0},             /* FS  */
+    {0, 0},             /* GS  */
+    {0, 0},             /* RS  */
+    {0, 0},             /* US  */
+    {0x2c, 0},          /*   */
+    {0x1e, KEY_SHIFT},      /* ! */
+    {0x34, KEY_SHIFT},      /* " */
+    {0x20, KEY_SHIFT},      /* # */
+    {0x21, KEY_SHIFT},      /* $ */
+    {0x22, KEY_SHIFT},      /* % */
+    {0x24, KEY_SHIFT},      /* & */
+    {0x34, 0},          /* ' */
+    {0x26, KEY_SHIFT},      /* ( */
+    {0x27, KEY_SHIFT},      /* ) */
+    {0x25, KEY_SHIFT},      /* * */
+    {0x2e, KEY_SHIFT},      /* + */
+    {0x36, 0},          /* , */
+    {0x2d, 0},          /* - */
+    {0x37, 0},          /* . */
+    {0x38, 0},          /* / */
+    {0x27, 0},          /* 0 */
+    {0x1e, 0},          /* 1 */
+    {0x1f, 0},          /* 2 */
+    {0x20, 0},          /* 3 */
+    {0x21, 0},          /* 4 */
+    {0x22, 0},          /* 5 */
+    {0x23, 0},          /* 6 */
+    {0x24, 0},          /* 7 */
+    {0x25, 0},          /* 8 */
+    {0x26, 0},          /* 9 */
+    {0x33, KEY_SHIFT},      /* : */
+    {0x33, 0},          /* ; */
+    {0x36, KEY_SHIFT},      /* < */
+    {0x2e, 0},          /* = */
+    {0x37, KEY_SHIFT},      /* > */
+    {0x38, KEY_SHIFT},      /* ? */
+    {0x1f, KEY_SHIFT},      /* @ */
+    {0x04, KEY_SHIFT},      /* A */
+    {0x05, KEY_SHIFT},      /* B */
+    {0x06, KEY_SHIFT},      /* C */
+    {0x07, KEY_SHIFT},      /* D */
+    {0x08, KEY_SHIFT},      /* E */
+    {0x09, KEY_SHIFT},      /* F */
+    {0x0a, KEY_SHIFT},      /* G */
+    {0x0b, KEY_SHIFT},      /* H */
+    {0x0c, KEY_SHIFT},      /* I */
+    {0x0d, KEY_SHIFT},      /* J */
+    {0x0e, KEY_SHIFT},      /* K */
+    {0x0f, KEY_SHIFT},      /* L */
+    {0x10, KEY_SHIFT},      /* M */
+    {0x11, KEY_SHIFT},      /* N */
+    {0x12, KEY_SHIFT},      /* O */
+    {0x13, KEY_SHIFT},      /* P */
+    {0x14, KEY_SHIFT},      /* Q */
+    {0x15, KEY_SHIFT},      /* R */
+    {0x16, KEY_SHIFT},      /* S */
+    {0x17, KEY_SHIFT},      /* T */
+    {0x18, KEY_SHIFT},      /* U */
+    {0x19, KEY_SHIFT},      /* V */
+    {0x1a, KEY_SHIFT},      /* W */
+    {0x1b, KEY_SHIFT},      /* X */
+    {0x1c, KEY_SHIFT},      /* Y */
+    {0x1d, KEY_SHIFT},      /* Z */
+    {0x2f, 0},          /* [ */
+    {0x31, 0},          /* \ */
+    {0x30, 0},          /* ] */
+    {0x23, KEY_SHIFT},      /* ^ */
+    {0x2d, KEY_SHIFT},      /* _ */
+    {0x35, 0},          /* ` */
+    {0x04, 0},          /* a */
+    {0x05, 0},          /* b */
+    {0x06, 0},          /* c */
+    {0x07, 0},          /* d */
+    {0x08, 0},          /* e */
+    {0x09, 0},          /* f */
+    {0x0a, 0},          /* g */
+    {0x0b, 0},          /* h */
+    {0x0c, 0},          /* i */
+    {0x0d, 0},          /* j */
+    {0x0e, 0},          /* k */
+    {0x0f, 0},          /* l */
+    {0x10, 0},          /* m */
+    {0x11, 0},          /* n */
+    {0x12, 0},          /* o */
+    {0x13, 0},          /* p */
+    {0x14, 0},          /* q */
+    {0x15, 0},          /* r */
+    {0x16, 0},          /* s */
+    {0x17, 0},          /* t */
+    {0x18, 0},          /* u */
+    {0x19, 0},          /* v */
+    {0x1a, 0},          /* w */
+    {0x1b, 0},          /* x */
+    {0x1c, 0},          /* y */
+    {0x1d, 0},          /* z */
+    {0x2f, KEY_SHIFT},      /* { */
+    {0x31, KEY_SHIFT},      /* | */
+    {0x30, KEY_SHIFT},      /* } */
+    {0x35, KEY_SHIFT},      /* ~ */
+    {0,0},              /* DEL */
+
+    {0x3a, 0},          /* F1 */
+    {0x3b, 0},          /* F2 */
+    {0x3c, 0},          /* F3 */
+    {0x3d, 0},          /* F4 */
+    {0x3e, 0},          /* F5 */
+    {0x3f, 0},          /* F6 */
+    {0x40, 0},          /* F7 */
+    {0x41, 0},          /* F8 */
+    {0x42, 0},          /* F9 */
+    {0x43, 0},          /* F10 */
+    {0x44, 0},          /* F11 */
+    {0x45, 0},          /* F12 */
+
+    {0x46, 0},          /* PRINT_SCREEN */
+    {0x47, 0},          /* SCROLL_LOCK */
+    {0x39, 0},          /* CAPS_LOCK */
+    {0x53, 0},          /* NUM_LOCK */
+    {0x49, 0},          /* INSERT */
+    {0x4a, 0},          /* HOME */
+    {0x4b, 0},          /* PAGE_UP */
+    {0x4e, 0},          /* PAGE_DOWN */
+
+    {0x4f, 0},          /* RIGHT_ARROW */
+    {0x50, 0},          /* LEFT_ARROW */
+    {0x51, 0},          /* DOWN_ARROW */
+    {0x52, 0},          /* UP_ARROW */
+};

--- a/src/layouts/ES_ES/hidkeylayout.h
+++ b/src/layouts/ES_ES/hidkeylayout.h
@@ -1,0 +1,177 @@
+#pragma once
+
+enum {
+    UK_LAYOUT,
+    US_LAYOUT
+};
+
+/* Modifiers */
+enum MODIFIER_KEY {
+        KEY_CTRL = 1,
+        KEY_SHIFT = 2,
+        KEY_ALT = 4,
+};
+
+typedef struct {
+        unsigned char usage;
+        unsigned char modifier;
+} KEYMAP;
+
+#define KEYMAP_SIZE (152)
+const KEYMAP keymap[KEYMAP_SIZE] = {
+  {0, 0},             // NUL
+  {0, 0},             // SOH
+  {0, 0},             // STX
+  {0, 0},             // ETX
+  {0, 0},             // EOT
+  {0, 0},             // ENQ
+  {0, 0},             // ACK
+  {0, 0},             // BEL
+  {0x2a, 0},      // BS  Backspace
+  {0x2b, 0},      // TAB  Tab
+  {0x28, 0},      // LF  Enter
+  {0, 0},             // VT
+  {0, 0},            // FF
+  {0, 0},             // CR
+  {0, 0},             // SO
+  {0, 0},             // SI
+  {0, 0},             // DEL
+  {0, 0},             // DC1
+  {0, 0},             // DC2
+  {0, 0},             // DC3
+  {0, 0},             // DC4
+  {0, 0},             // NAK
+  {0, 0},             // SYN
+  {0, 0},             // ETB
+  {0, 0},             // CAN
+  {0, 0},             // EM
+  {0, 0},             // SUB
+  {0, 0},             // ESC
+  {0, 0},             // FS
+  {0, 0},             // GS
+  {0, 0},             // RS
+  {0, 0},             // US
+  {0x2c, 0},          //  ' ' (space)
+  {0x1e, KEY_SHIFT},   // !
+  {0x1f, KEY_SHIFT},    // "
+  {0x20, KEYBOARD_MODIFIER_RIGHTALT},    // #
+  {0x21, KEY_SHIFT},   // $
+  {0x22, KEY_SHIFT},   // %
+  {0x23, KEY_SHIFT},   // &
+  {0x2d, 0},          // '
+  {0x25, KEY_SHIFT},   // (
+  {0x26, KEY_SHIFT},   // )
+  {0x30, KEY_SHIFT},   // *
+  {0x30, 0},          // +
+  {0x36, 0},          // ,
+  {0x38, 0},          // -
+  {0x37, 0},          // .
+  {0x24, KEY_SHIFT},   // /
+  {0x27, 0},          // 0
+  {0x1e, 0},          // 1
+  {0x1f, 0},          // 2
+  {0x20, 0},          // 3
+  {0x21, 0},          // 4
+  {0x22, 0},          // 5
+  {0x23, 0},          // 6
+  {0x24, 0},          // 7
+  {0x25, 0},          // 8
+  {0x26, 0},          // 9
+  {0x37, KEY_SHIFT},     // :
+  {0x36, KEY_SHIFT},     // ;
+  {0x64, 0},            // < //KEY_NON_US_100
+  {0x27, KEY_SHIFT},     // =
+  {0x64, KEY_SHIFT},     // > //KEY_NON_US_100 + SHIFT
+  {0x2d, KEY_SHIFT},      // ?
+  {0x1f, KEYBOARD_MODIFIER_RIGHTALT},    // @
+  {0x04, KEY_SHIFT},     // A
+  {0x05, KEY_SHIFT},     // B
+  {0x06, KEY_SHIFT},     // C
+  {0x07, KEY_SHIFT},     // D
+  {0x08, KEY_SHIFT},     // E
+  {0x09, KEY_SHIFT},     // F
+  {0x0a, KEY_SHIFT},     // G
+  {0x0b, KEY_SHIFT},     // H
+  {0x0c, KEY_SHIFT},     // I
+  {0x0d, KEY_SHIFT},     // J
+  {0x0e, KEY_SHIFT},     // K
+  {0x0f, KEY_SHIFT},     // L
+  {0x10, KEY_SHIFT},     // M
+  {0x11, KEY_SHIFT},     // N
+  {0x12, KEY_SHIFT},     // O
+  {0x13, KEY_SHIFT},     // P
+  {0x14, KEY_SHIFT},     // Q
+  {0x15, KEY_SHIFT},     // R
+  {0x16, KEY_SHIFT},     // S
+  {0x17, KEY_SHIFT},     // T
+  {0x18, KEY_SHIFT},     // U
+  {0x19, KEY_SHIFT},     // V
+  {0x1a, KEY_SHIFT},     // W
+  {0x1b, KEY_SHIFT},     // X
+  {0x1c, KEY_SHIFT},      // Y
+  {0x1d, KEY_SHIFT},      // Z
+  {0x2f, KEYBOARD_MODIFIER_RIGHTALT},      // [
+  {0x35, KEYBOARD_MODIFIER_RIGHTALT},      // bslash
+  {0x30, KEYBOARD_MODIFIER_RIGHTALT},      // ]
+  {0x2f, KEY_SHIFT},    // ^
+  {0x38, KEY_SHIFT},    // _
+  {0x2f, 0},           // `
+  {0x04, 0},          // a
+  {0x05, 0},          // b
+  {0x06, 0},          // c
+  {0x07, 0},          // d
+  {0x08, 0},          // e
+  {0x09, 0},          // f
+  {0x0a, 0},          // g
+  {0x0b, 0},          // h
+  {0x0c, 0},          // i
+  {0x0d, 0},          // j
+  {0x0e, 0},          // k
+  {0x0f, 0},          // l
+  {0x10, 0},          // m
+  {0x11, 0},          // n
+  {0x12, 0},          // o
+  {0x13, 0},          // p
+  {0x14, 0},          // q
+  {0x15, 0},          // r
+  {0x16, 0},          // s
+  {0x17, 0},          // t
+  {0x18, 0},          // u
+  {0x19, 0},          // v
+  {0x1a, 0},          // w
+  {0x1b, 0},          // x
+  {0x1c, 0},          // y
+  {0x1d, 0},          // z
+  {0x34, KEYBOARD_MODIFIER_RIGHTALT},    // {
+  {0x1e, KEYBOARD_MODIFIER_RIGHTALT},    // |
+  {0x32, KEYBOARD_MODIFIER_RIGHTALT},    // }
+  {0x21, KEYBOARD_MODIFIER_RIGHTALT},    // ~
+  {0,0},              /* DEL */
+  
+  {0x3a, 0},          /* F1 */
+  {0x3b, 0},          /* F2 */
+  {0x3c, 0},          /* F3 */
+  {0x3d, 0},          /* F4 */
+  {0x3e, 0},          /* F5 */
+  {0x3f, 0},          /* F6 */
+  {0x40, 0},          /* F7 */
+  {0x41, 0},          /* F8 */
+  {0x42, 0},          /* F9 */
+  {0x43, 0},          /* F10 */
+  {0x44, 0},          /* F11 */
+  {0x45, 0},          /* F12 */
+    
+  {0x46, 0},          /* PRINT_SCREEN */
+  {0x47, 0},          /* SCROLL_LOCK */
+  {0x39, 0},          /* CAPS_LOCK */
+  {0x53, 0},          /* NUM_LOCK */
+  {0x49, 0},          /* INSERT */
+  {0x4a, 0},          /* HOME */
+  {0x4b, 0},          /* PAGE_UP */
+  {0x4e, 0},          /* PAGE_DOWN */
+  
+  {0x4f, 0},          /* RIGHT_ARROW */
+  {0x50, 0},          /* LEFT_ARROW */
+  {0x51, 0},          /* DOWN_ARROW */
+  {0x52, 0},          /* UP_ARROW */
+};

--- a/src/layouts/FI_FI/hidkeylayout.h
+++ b/src/layouts/FI_FI/hidkeylayout.h
@@ -1,0 +1,177 @@
+#pragma once
+
+enum {
+    UK_LAYOUT,
+    US_LAYOUT
+};
+
+/* Modifiers */
+enum MODIFIER_KEY {
+        KEY_CTRL = 1,
+        KEY_SHIFT = 2,
+        KEY_ALT = 4,
+};
+
+typedef struct {
+        unsigned char usage;
+        unsigned char modifier;
+} KEYMAP;
+
+#define KEYMAP_SIZE (152)
+const KEYMAP keymap[KEYMAP_SIZE] = {
+    {0, 0},             /* NUL */
+    {0, 0},             /* SOH */
+    {0, 0},             /* STX */
+    {0, 0},             /* ETX */
+    {0, 0},             /* EOT */
+    {0, 0},             /* ENQ */
+    {0, 0},             /* ACK */
+    {0, 0},             /* BEL */
+    {0x2a, 0},          /* BS  */  /* Keyboard Delete (Backspace) */
+    {0x2b, 0},          /* TAB */  /* Keyboard Tab */
+    {0x28, 0},          /* LF  */  /* Keyboard Return (Enter) */
+    {0, 0},             /* VT  */
+    {0, 0},             /* FF  */
+    {0, 0},             /* CR  */
+    {0, 0},             /* SO  */
+    {0, 0},             /* SI  */
+    {0, 0},             /* DEL */
+    {0, 0},             /* DC1 */
+    {0, 0},             /* DC2 */
+    {0, 0},             /* DC3 */
+    {0, 0},             /* DC4 */
+    {0, 0},             /* NAK */
+    {0, 0},             /* SYN */
+    {0, 0},             /* ETB */
+    {0, 0},             /* CAN */
+    {0, 0},             /* EM  */
+    {0, 0},             /* SUB */
+    {0, 0},             /* ESC */
+    {0, 0},             /* FS  */
+    {0, 0},             /* GS  */
+    {0, 0},             /* RS  */
+    {0, 0},             /* US  */
+    {0x2c, 0},          /*   */
+    {0x1e, KEY_SHIFT},      /* ! */
+    {0x1f, KEY_SHIFT},      /* " */
+    {0x20, KEY_SHIFT},      /* # */
+    {0x21, 0},      /* $ */
+    {0x22, KEY_SHIFT},      /* % */
+    {0x23, KEY_SHIFT},      /* & */
+    {0x31, 0},          /* ' */
+    {0x25, KEY_SHIFT},      /* ( */
+    {0x26, KEY_SHIFT},      /* ) */
+    {0x31, KEY_SHIFT},      /* * */
+    {0x2d, 0},      /* + */
+    {0x36, 0},          /* , */
+    {0x38, 0},          /* - */
+    {0x37, 0},          /* . */
+    {0x24, KEY_SHIFT},          /* / */
+    {0x27, 0},          /* 0 */
+    {0x1e, 0},          /* 1 */
+    {0x1f, 0},          /* 2 */
+    {0x20, 0},          /* 3 */
+    {0x21, 0},          /* 4 */
+    {0x22, 0},          /* 5 */
+    {0x23, 0},          /* 6 */
+    {0x24, 0},          /* 7 */
+    {0x25, 0},          /* 8 */
+    {0x26, 0},          /* 9 */
+    {0x37, KEY_SHIFT},      /* : */
+    {0x36, KEY_SHIFT},          /* ; */
+    {0x64, 0},      /* < */
+    {0x27, KEY_SHIFT},          /* = */
+    {0x64, KEY_SHIFT},      /* > */
+    {0x2d, KEY_SHIFT},      /* ? */
+    {0x1f, 0},      /* @ */
+    {0x04, KEY_SHIFT},      /* A */
+    {0x05, KEY_SHIFT},      /* B */
+    {0x06, KEY_SHIFT},      /* C */
+    {0x07, KEY_SHIFT},      /* D */
+    {0x08, KEY_SHIFT},      /* E */
+    {0x09, KEY_SHIFT},      /* F */
+    {0x0a, KEY_SHIFT},      /* G */
+    {0x0b, KEY_SHIFT},      /* H */
+    {0x0c, KEY_SHIFT},      /* I */
+    {0x0d, KEY_SHIFT},      /* J */
+    {0x0e, KEY_SHIFT},      /* K */
+    {0x0f, KEY_SHIFT},      /* L */
+    {0x10, KEY_SHIFT},      /* M */
+    {0x11, KEY_SHIFT},      /* N */
+    {0x12, KEY_SHIFT},      /* O */
+    {0x13, KEY_SHIFT},      /* P */
+    {0x14, KEY_SHIFT},      /* Q */
+    {0x15, KEY_SHIFT},      /* R */
+    {0x16, KEY_SHIFT},      /* S */
+    {0x17, KEY_SHIFT},      /* T */
+    {0x18, KEY_SHIFT},      /* U */
+    {0x19, KEY_SHIFT},      /* V */
+    {0x1a, KEY_SHIFT},      /* W */
+    {0x1b, KEY_SHIFT},      /* X */
+    {0x1c, KEY_SHIFT},      /* Y */
+    {0x1d, KEY_SHIFT},      /* Z */
+    {0x25, 0},          /* [ */
+    {0x2d, 0},          /* \ */
+    {0x26, 0},          /* ] */
+    {0x23, 0},      /* ^ */
+    {0x38, KEY_SHIFT},      /* _ */
+    {0x2d, KEY_SHIFT},          /* ` */
+    {0x04, 0},          /* a */
+    {0x05, 0},          /* b */
+    {0x06, 0},          /* c */
+    {0x07, 0},          /* d */
+    {0x08, 0},          /* e */
+    {0x09, 0},          /* f */
+    {0x0a, 0},          /* g */
+    {0x0b, 0},          /* h */
+    {0x0c, 0},          /* i */
+    {0x0d, 0},          /* j */
+    {0x0e, 0},          /* k */
+    {0x0f, 0},          /* l */
+    {0x10, 0},          /* m */
+    {0x11, 0},          /* n */
+    {0x12, 0},          /* o */
+    {0x13, 0},          /* p */
+    {0x14, 0},          /* q */
+    {0x15, 0},          /* r */
+    {0x16, 0},          /* s */
+    {0x17, 0},          /* t */
+    {0x18, 0},          /* u */
+    {0x19, 0},          /* v */
+    {0x1a, 0},          /* w */
+    {0x1b, 0},          /* x */
+    {0x1c, 0},          /* y */
+    {0x1d, 0},          /* z */
+    {0x24, 0},      /* { */
+    {0x36, 0},      /* | */
+    {0x27, 0},      /* } */
+    {0x2d, 0},      /* ~ */
+    {0,0},              /* DEL */
+
+    {0x3a, 0},          /* F1 */
+    {0x3b, 0},          /* F2 */
+    {0x3c, 0},          /* F3 */
+    {0x3d, 0},          /* F4 */
+    {0x3e, 0},          /* F5 */
+    {0x3f, 0},          /* F6 */
+    {0x40, 0},          /* F7 */
+    {0x41, 0},          /* F8 */
+    {0x42, 0},          /* F9 */
+    {0x43, 0},          /* F10 */
+    {0x44, 0},          /* F11 */
+    {0x45, 0},          /* F12 */
+
+    {0x46, 0},          /* PRINT_SCREEN */
+    {0x47, 0},          /* SCROLL_LOCK */
+    {0x39, 0},          /* CAPS_LOCK */
+    {0x53, 0},          /* NUM_LOCK */
+    {0x49, 0},          /* INSERT */
+    {0x4a, 0},          /* HOME */
+    {0x4b, 0},          /* PAGE_UP */
+    {0x4e, 0},          /* PAGE_DOWN */
+
+    {0x4f, 0},          /* RIGHT_ARROW */
+    {0x50, 0},          /* LEFT_ARROW */
+    {0x51, 0},          /* DOWN_ARROW */
+    {0x52, 0},          /* UP_ARROW */
+};

--- a/src/layouts/FR_FR/hidkeylayout.h
+++ b/src/layouts/FR_FR/hidkeylayout.h
@@ -1,0 +1,183 @@
+#pragma once
+
+enum {
+    UK_LAYOUT,
+    US_LAYOUT
+};
+
+/* Modifiers */
+enum MODIFIER_KEY {
+        KEY_CTRL = 1,
+        KEY_SHIFT = 2,
+        KEY_ALT = 4,
+};
+
+typedef struct {
+        unsigned char usage;
+        unsigned char modifier;
+} KEYMAP;
+
+#define HID_KEY_A 0x14
+#define HID_KEY_M 0x33
+#define HID_KEY_Q 0x04
+#define HID_KEY_W 0x1d
+#define HID_KEY_Z 0x1a
+
+#define KEYMAP_SIZE (152)
+const KEYMAP keymap[KEYMAP_SIZE] = {
+    {0, 0},             /* NUL */
+    {0, 0},             /* SOH */
+    {0, 0},             /* STX */
+    {0, 0},             /* ETX */
+    {0, 0},             /* EOT */
+    {0, 0},             /* ENQ */
+    {0, 0},             /* ACK */
+    {0, 0},             /* BEL */
+    {0x2a, 0},          /* BS  */  /* Keyboard Delete (Backspace) */
+    {0x2b, 0},          /* TAB */  /* Keyboard Tab */
+    {0x28, 0},          /* LF  */  /* Keyboard Return (Enter) */
+    {0, 0},             /* VT  */
+    {0, 0},             /* FF  */
+    {0, 0},             /* CR  */
+    {0, 0},             /* SO  */
+    {0, 0},             /* SI  */
+    {0, 0},             /* DEL */
+    {0, 0},             /* DC1 */
+    {0, 0},             /* DC2 */
+    {0, 0},             /* DC3 */
+    {0, 0},             /* DC4 */
+    {0, 0},             /* NAK */
+    {0, 0},             /* SYN */
+    {0, 0},             /* ETB */
+    {0, 0},             /* CAN */
+    {0, 0},             /* EM  */
+    {0, 0},             /* SUB */
+    {0, 0},             /* ESC */
+    {0, 0},             /* FS  */
+    {0, 0},             /* GS  */
+    {0, 0},             /* RS  */
+    {0, 0},             /* US  */
+    {0x2c, 0},          /*   */
+    {0x38, 0},      /* ! */
+    {0x20, 0},      /* " */
+    {0x20, 0},      /* # */
+    {0x30, 0},      /* $ */
+    {0x34, KEY_SHIFT},      /* % */
+    {0x1e, 0},      /* & */
+    {0x21, 0},          /* ' */
+    {0x22, 0},      /* ( */
+    {0x2d, 0},      /* ) */
+    {0x31, 0},      /* * */
+    {0x2e, KEY_SHIFT},      /* + */
+    {0x10, 0},          /* , */
+    {0x23, 0},          /* - */
+    {0x36, KEY_SHIFT},          /* . */
+    {0x37, KEY_SHIFT},          /* / */
+    {0x27, KEY_SHIFT},          /* 0 */
+    {0x1e, KEY_SHIFT},          /* 1 */
+    {0x1f, KEY_SHIFT},          /* 2 */
+    {0x20, KEY_SHIFT},          /* 3 */
+    {0x21, KEY_SHIFT},          /* 4 */
+    {0x22, KEY_SHIFT},          /* 5 */
+    {0x23, KEY_SHIFT},          /* 6 */
+    {0x24, KEY_SHIFT},          /* 7 */
+    {0x25, KEY_SHIFT},          /* 8 */
+    {0x26, KEY_SHIFT},          /* 9 */
+    {0x37, 0},      /* : */
+    {0x36, 0},          /* ; */
+    {0x64, KEY_SHIFT},      /* < */
+    {0x2e, 0},          /* = */
+    {0x64, KEY_SHIFT},      /* > */
+    {0x10, KEY_SHIFT},      /* ? */
+    {0x27, 0},      /* @ */
+    {0x14, KEY_SHIFT},      /* A */
+    {0x05, KEY_SHIFT},      /* B */
+    {0x06, KEY_SHIFT},      /* C */
+    {0x07, KEY_SHIFT},      /* D */
+    {0x08, KEY_SHIFT},      /* E */
+    {0x09, KEY_SHIFT},      /* F */
+    {0x0a, KEY_SHIFT},      /* G */
+    {0x0b, KEY_SHIFT},      /* H */
+    {0x0c, KEY_SHIFT},      /* I */
+    {0x0d, KEY_SHIFT},      /* J */
+    {0x0e, KEY_SHIFT},      /* K */
+    {0x0f, KEY_SHIFT},      /* L */
+    {0x33, KEY_SHIFT},      /* M */
+    {0x11, KEY_SHIFT},      /* N */
+    {0x12, KEY_SHIFT},      /* O */
+    {0x13, KEY_SHIFT},      /* P */
+    {0x04, KEY_SHIFT},      /* Q */
+    {0x15, KEY_SHIFT},      /* R */
+    {0x16, KEY_SHIFT},      /* S */
+    {0x17, KEY_SHIFT},      /* T */
+    {0x18, KEY_SHIFT},      /* U */
+    {0x19, KEY_SHIFT},      /* V */
+    {0x1d, KEY_SHIFT},      /* W */
+    {0x1b, KEY_SHIFT},      /* X */
+    {0x1c, KEY_SHIFT},      /* Y */
+    {0x1a, KEY_SHIFT},      /* Z */
+    {0x22, 0},          /* [ */
+    {0x25, 0},          /* \ */
+    {0x2d, 0},          /* ] */
+    {0x26, 0},      /* ^ */
+    {0x25, 0},      /* _ */
+    {0x24, 0},          /* ` */
+    {0x14, 0},      /* a */
+    {0x05, 0},     /* b */
+    {0x06, 0},      /* c */
+    {0x07, 0},      /* d */
+    {0x08, 0},      /* e */
+    {0x09, 0},      /* f */
+    {0x0a, 0},      /* g */
+    {0x0b, 0},      /* h */
+    {0x0c, 0},      /* i */
+    {0x0d, 0},      /* j */
+    {0x0e, 0},      /* k */
+    {0x0f, 0},      /* l */
+    {0x33, 0},      /* m */
+    {0x11, 0},      /* n */
+    {0x12, 0},      /* o */
+    {0x13, 0},      /* p */
+    {0x04, 0},      /* q */
+    {0x15, 0},      /* r */
+    {0x16, 0},      /* s */
+    {0x17, 0},      /* t */
+    {0x18, 0},      /* u */
+    {0x19, 0},      /* v */
+    {0x1d, 0},      /* w */
+    {0x1b, 0},      /* x */
+    {0x1c, 0},      /* y */
+    {0x1a, 0},      /* z */
+    {0x21, 0},      /* { */
+    {0x23, 0},      /* | */
+    {0x2e, 0},      /* } */
+    {0x1f, 0},      /* ~ */
+    {0,0},              /* DEL */
+
+    {0x3a, 0},          /* F1 */
+    {0x3b, 0},          /* F2 */
+    {0x3c, 0},          /* F3 */
+    {0x3d, 0},          /* F4 */
+    {0x3e, 0},          /* F5 */
+    {0x3f, 0},          /* F6 */
+    {0x40, 0},          /* F7 */
+    {0x41, 0},          /* F8 */
+    {0x42, 0},          /* F9 */
+    {0x43, 0},          /* F10 */
+    {0x44, 0},          /* F11 */
+    {0x45, 0},          /* F12 */
+
+    {0x46, 0},          /* PRINT_SCREEN */
+    {0x47, 0},          /* SCROLL_LOCK */
+    {0x39, 0},          /* CAPS_LOCK */
+    {0x53, 0},          /* NUM_LOCK */
+    {0x49, 0},          /* INSERT */
+    {0x4a, 0},          /* HOME */
+    {0x4b, 0},          /* PAGE_UP */
+    {0x4e, 0},          /* PAGE_DOWN */
+
+    {0x4f, 0},          /* RIGHT_ARROW */
+    {0x50, 0},          /* LEFT_ARROW */
+    {0x51, 0},          /* DOWN_ARROW */
+    {0x52, 0},          /* UP_ARROW */
+};

--- a/src/layouts/IT_IT/hidkeylayout.h
+++ b/src/layouts/IT_IT/hidkeylayout.h
@@ -1,0 +1,177 @@
+#pragma once
+
+enum {
+    UK_LAYOUT,
+    US_LAYOUT
+};
+
+/* Modifiers */
+enum MODIFIER_KEY {
+        KEY_CTRL = 1,
+        KEY_SHIFT = 2,
+        KEY_ALT = 4,
+};
+
+typedef struct {
+        unsigned char usage;
+        unsigned char modifier;
+} KEYMAP;
+
+#define KEYMAP_SIZE (152)
+const KEYMAP keymap[KEYMAP_SIZE] = {
+    {0, 0},             /* NUL */
+    {0, 0},             /* SOH */
+    {0, 0},             /* STX */
+    {0, 0},             /* ETX */
+    {0, 0},             /* EOT */
+    {0, 0},             /* ENQ */
+    {0, 0},             /* ACK */
+    {0, 0},             /* BEL */
+    {0x2a, 0},          /* BS  */  /* Keyboard Delete (Backspace) */
+    {0x2b, 0},          /* TAB */  /* Keyboard Tab */
+    {0x28, 0},          /* LF  */  /* Keyboard Return (Enter) */
+    {0, 0},             /* VT  */
+    {0, 0},             /* FF  */
+    {0, 0},             /* CR  */
+    {0, 0},             /* SO  */
+    {0, 0},             /* SI  */
+    {0, 0},             /* DEL */
+    {0, 0},             /* DC1 */
+    {0, 0},             /* DC2 */
+    {0, 0},             /* DC3 */
+    {0, 0},             /* DC4 */
+    {0, 0},             /* NAK */
+    {0, 0},             /* SYN */
+    {0, 0},             /* ETB */
+    {0, 0},             /* CAN */
+    {0, 0},             /* EM  */
+    {0, 0},             /* SUB */
+    {0, 0},             /* ESC */
+    {0, 0},             /* FS  */
+    {0, 0},             /* GS  */
+    {0, 0},             /* RS  */
+    {0, 0},             /* US  */
+    {0x2c, 0},          /*   */
+    {0x1e, KEY_SHIFT},      /* ! */
+    {0x1f, KEY_SHIFT},      /* " */
+    {0x34, 0},      /* # */
+    {0x21, KEY_SHIFT},      /* $ */
+    {0x22, KEY_SHIFT},      /* % */
+    {0x23, KEY_SHIFT},      /* & */
+    {0x2d, 0},          /* ' */
+    {0x25, KEY_SHIFT},      /* ( */
+    {0x26, KEY_SHIFT},      /* ) */
+    {0x30, KEY_SHIFT},      /* * */
+    {0x30, 0},      /* + */
+    {0x36, 0},          /* , */
+    {0x38, 0},          /* - */
+    {0x37, 0},          /* . */
+    {0x24, KEY_SHIFT},          /* / */
+    {0x27, 0},          /* 0 */
+    {0x1e, 0},          /* 1 */
+    {0x1f, 0},          /* 2 */
+    {0x20, 0},          /* 3 */
+    {0x21, 0},          /* 4 */
+    {0x22, 0},          /* 5 */
+    {0x23, 0},          /* 6 */
+    {0x24, 0},          /* 7 */
+    {0x25, 0},          /* 8 */
+    {0x26, 0},          /* 9 */
+    {0x37, KEY_SHIFT},      /* : */
+    {0x36, KEY_SHIFT},          /* ; */
+    {0x64, 0},      /* < */
+    {0x27, KEY_SHIFT},          /* = */
+    {0x64, KEY_SHIFT},      /* > */
+    {0x2d, KEY_SHIFT},      /* ? */
+    {0x33, 0},      /* @ */
+    {0x04, KEY_SHIFT},      /* A */
+    {0x05, KEY_SHIFT},      /* B */
+    {0x06, KEY_SHIFT},      /* C */
+    {0x07, KEY_SHIFT},      /* D */
+    {0x08, KEY_SHIFT},      /* E */
+    {0x09, KEY_SHIFT},      /* F */
+    {0x0a, KEY_SHIFT},      /* G */
+    {0x0b, KEY_SHIFT},      /* H */
+    {0x0c, KEY_SHIFT},      /* I */
+    {0x0d, KEY_SHIFT},      /* J */
+    {0x0e, KEY_SHIFT},      /* K */
+    {0x0f, KEY_SHIFT},      /* L */
+    {0x10, KEY_SHIFT},      /* M */
+    {0x11, KEY_SHIFT},      /* N */
+    {0x12, KEY_SHIFT},      /* O */
+    {0x13, KEY_SHIFT},      /* P */
+    {0x14, KEY_SHIFT},      /* Q */
+    {0x15, KEY_SHIFT},      /* R */
+    {0x16, KEY_SHIFT},      /* S */
+    {0x17, KEY_SHIFT},      /* T */
+    {0x18, KEY_SHIFT},      /* U */
+    {0x19, KEY_SHIFT},      /* V */
+    {0x1a, KEY_SHIFT},      /* W */
+    {0x1b, KEY_SHIFT},      /* X */
+    {0x1c, KEY_SHIFT},      /* Y */
+    {0x1d, KEY_SHIFT},      /* Z */
+    {0x2f, 0},          /* [ */
+    {0x35, 0},          /* \ */
+    {0x30, 0},          /* ] */
+    {0x2e, KEY_SHIFT},      /* ^ */
+    {0x38, KEY_SHIFT},      /* _ */
+    {0x35, 0},          /* ` */
+    {0x04, 0},          /* a */
+    {0x05, 0},          /* b */
+    {0x06, 0},          /* c */
+    {0x07, 0},          /* d */
+    {0x08, 0},          /* e */
+    {0x09, 0},          /* f */
+    {0x0a, 0},          /* g */
+    {0x0b, 0},          /* h */
+    {0x0c, 0},          /* i */
+    {0x0d, 0},          /* j */
+    {0x0e, 0},          /* k */
+    {0x0f, 0},          /* l */
+    {0x10, 0},          /* m */
+    {0x11, 0},          /* n */
+    {0x12, 0},          /* o */
+    {0x13, 0},          /* p */
+    {0x14, 0},          /* q */
+    {0x15, 0},          /* r */
+    {0x16, 0},          /* s */
+    {0x17, 0},          /* t */
+    {0x18, 0},          /* u */
+    {0x19, 0},          /* v */
+    {0x1a, 0},          /* w */
+    {0x1b, 0},          /* x */
+    {0x1c, 0},          /* y */
+    {0x1d, 0},          /* z */
+    {0x2f, KEY_SHIFT},      /* { */
+    {0x35, KEY_SHIFT},      /* | */
+    {0x30, KEY_SHIFT},      /* } */
+    {0x34, 0},      /* ~ */
+    {0,0},              /* DEL */
+
+    {0x3a, 0},          /* F1 */
+    {0x3b, 0},          /* F2 */
+    {0x3c, 0},          /* F3 */
+    {0x3d, 0},          /* F4 */
+    {0x3e, 0},          /* F5 */
+    {0x3f, 0},          /* F6 */
+    {0x40, 0},          /* F7 */
+    {0x41, 0},          /* F8 */
+    {0x42, 0},          /* F9 */
+    {0x43, 0},          /* F10 */
+    {0x44, 0},          /* F11 */
+    {0x45, 0},          /* F12 */
+
+    {0x46, 0},          /* PRINT_SCREEN */
+    {0x47, 0},          /* SCROLL_LOCK */
+    {0x39, 0},          /* CAPS_LOCK */
+    {0x53, 0},          /* NUM_LOCK */
+    {0x49, 0},          /* INSERT */
+    {0x4a, 0},          /* HOME */
+    {0x4b, 0},          /* PAGE_UP */
+    {0x4e, 0},          /* PAGE_DOWN */
+
+    {0x4f, 0},          /* RIGHT_ARROW */
+    {0x50, 0},          /* LEFT_ARROW */
+    {0x51, 0},          /* DOWN_ARROW */
+    {0x52, 0},          /* UP_ARROW */
+};

--- a/src/layouts/PT_BR/hidkeylayout.h
+++ b/src/layouts/PT_BR/hidkeylayout.h
@@ -1,0 +1,177 @@
+#pragma once
+
+enum {
+    UK_LAYOUT,
+    US_LAYOUT
+};
+
+/* Modifiers */
+enum MODIFIER_KEY {
+        KEY_CTRL = 1,
+        KEY_SHIFT = 2,
+        KEY_ALT = 4,
+};
+
+typedef struct {
+        unsigned char usage;
+        unsigned char modifier;
+} KEYMAP;
+
+#define KEYMAP_SIZE (152)
+const KEYMAP keymap[KEYMAP_SIZE] = {
+    {0, 0},             /* NUL */
+    {0, 0},             /* SOH */
+    {0, 0},             /* STX */
+    {0, 0},             /* ETX */
+    {0, 0},             /* EOT */
+    {0, 0},             /* ENQ */
+    {0, 0},             /* ACK */
+    {0, 0},             /* BEL */
+    {0x2a, 0},          /* BS  */  /* Keyboard Delete (Backspace) */
+    {0x2b, 0},          /* TAB */  /* Keyboard Tab */
+    {0x28, 0},          /* LF  */  /* Keyboard Return (Enter) */
+    {0, 0},             /* VT  */
+    {0, 0},             /* FF  */
+    {0, 0},             /* CR  */
+    {0, 0},             /* SO  */
+    {0, 0},             /* SI  */
+    {0, 0},             /* DEL */
+    {0, 0},             /* DC1 */
+    {0, 0},             /* DC2 */
+    {0, 0},             /* DC3 */
+    {0, 0},             /* DC4 */
+    {0, 0},             /* NAK */
+    {0, 0},             /* SYN */
+    {0, 0},             /* ETB */
+    {0, 0},             /* CAN */
+    {0, 0},             /* EM  */
+    {0, 0},             /* SUB */
+    {0, 0},             /* ESC */
+    {0, 0},             /* FS  */
+    {0, 0},             /* GS  */
+    {0, 0},             /* RS  */
+    {0, 0},             /* US  */
+    {0x2c, 0},          /*   */
+    {0x1e, KEY_SHIFT},      /* ! */
+    {0x35, KEY_SHIFT},      /* " */
+    {0x20, KEY_SHIFT},      /* # */
+    {0x21, KEY_SHIFT},      /* $ */
+    {0x22, KEY_SHIFT},      /* % */
+    {0x24, KEY_SHIFT},      /* & */
+    {0x35, 0},          /* ' */
+    {0x26, KEY_SHIFT},      /* ( */
+    {0x27, KEY_SHIFT},      /* ) */
+    {0x25, KEY_SHIFT},      /* * */
+    {0x2e, KEY_SHIFT},      /* + */
+    {0x36, 0},          /* , */
+    {0x2d, 0},          /* - */
+    {0x37, 0},          /* . */
+    {0x14, 0},          /* / */
+    {0x27, 0},          /* 0 */
+    {0x1e, 0},          /* 1 */
+    {0x1f, 0},          /* 2 */
+    {0x20, 0},          /* 3 */
+    {0x21, 0},          /* 4 */
+    {0x22, 0},          /* 5 */
+    {0x23, 0},          /* 6 */
+    {0x24, 0},          /* 7 */
+    {0x25, 0},          /* 8 */
+    {0x26, 0},          /* 9 */
+    {0x38, KEY_SHIFT},      /* : */
+    {0x38, 0},          /* ; */
+    {0x36, KEY_SHIFT},      /* < */
+    {0x2e, 0},          /* = */
+    {0x37, KEY_SHIFT},      /* > */
+    {0x1a, 0},      /* ? */
+    {0x1f, KEY_SHIFT},      /* @ */
+    {0x04, KEY_SHIFT},      /* A */
+    {0x05, KEY_SHIFT},      /* B */
+    {0x06, KEY_SHIFT},      /* C */
+    {0x07, KEY_SHIFT},      /* D */
+    {0x08, KEY_SHIFT},      /* E */
+    {0x09, KEY_SHIFT},      /* F */
+    {0x0a, KEY_SHIFT},      /* G */
+    {0x0b, KEY_SHIFT},      /* H */
+    {0x0c, KEY_SHIFT},      /* I */
+    {0x0d, KEY_SHIFT},      /* J */
+    {0x0e, KEY_SHIFT},      /* K */
+    {0x0f, KEY_SHIFT},      /* L */
+    {0x10, KEY_SHIFT},      /* M */
+    {0x11, KEY_SHIFT},      /* N */
+    {0x12, KEY_SHIFT},      /* O */
+    {0x13, KEY_SHIFT},      /* P */
+    {0x14, KEY_SHIFT},      /* Q */
+    {0x15, KEY_SHIFT},      /* R */
+    {0x16, KEY_SHIFT},      /* S */
+    {0x17, KEY_SHIFT},      /* T */
+    {0x18, KEY_SHIFT},      /* U */
+    {0x19, KEY_SHIFT},      /* V */
+    {0x1a, KEY_SHIFT},      /* W */
+    {0x1b, KEY_SHIFT},      /* X */
+    {0x1c, KEY_SHIFT},      /* Y */
+    {0x1d, KEY_SHIFT},      /* Z */
+    {0x30, 0},          /* [ */
+    {0x30, 0},          /* \ */
+    {0x31, 0},          /* ] */
+    {0x34, KEY_SHIFT},      /* ^ */
+    {0x2d, KEY_SHIFT},      /* _ */
+    {0x2f, KEY_SHIFT},          /* ` */
+    {0x04, 0},          /* a */
+    {0x05, 0},          /* b */
+    {0x06, 0},          /* c */
+    {0x07, 0},          /* d */
+    {0x08, 0},          /* e */
+    {0x09, 0},          /* f */
+    {0x0a, 0},          /* g */
+    {0x0b, 0},          /* h */
+    {0x0c, 0},          /* i */
+    {0x0d, 0},          /* j */
+    {0x0e, 0},          /* k */
+    {0x0f, 0},          /* l */
+    {0x10, 0},          /* m */
+    {0x11, 0},          /* n */
+    {0x12, 0},          /* o */
+    {0x13, 0},          /* p */
+    {0x14, 0},          /* q */
+    {0x15, 0},          /* r */
+    {0x16, 0},          /* s */
+    {0x17, 0},          /* t */
+    {0x18, 0},          /* u */
+    {0x19, 0},          /* v */
+    {0x1a, 0},          /* w */
+    {0x1b, 0},          /* x */
+    {0x1c, 0},          /* y */
+    {0x1d, 0},          /* z */
+    {0x30, KEY_SHIFT},      /* { */
+    {0x2f, KEY_SHIFT},      /* | */
+    {0x31, KEY_SHIFT},      /* } */
+    {0x34, 0},      /* ~ */
+    {0,0},              /* DEL */
+
+    {0x3a, 0},          /* F1 */
+    {0x3b, 0},          /* F2 */
+    {0x3c, 0},          /* F3 */
+    {0x3d, 0},          /* F4 */
+    {0x3e, 0},          /* F5 */
+    {0x3f, 0},          /* F6 */
+    {0x40, 0},          /* F7 */
+    {0x41, 0},          /* F8 */
+    {0x42, 0},          /* F9 */
+    {0x43, 0},          /* F10 */
+    {0x44, 0},          /* F11 */
+    {0x45, 0},          /* F12 */
+
+    {0x46, 0},          /* PRINT_SCREEN */
+    {0x47, 0},          /* SCROLL_LOCK */
+    {0x39, 0},          /* CAPS_LOCK */
+    {0x53, 0},          /* NUM_LOCK */
+    {0x49, 0},          /* INSERT */
+    {0x4a, 0},          /* HOME */
+    {0x4b, 0},          /* PAGE_UP */
+    {0x4e, 0},          /* PAGE_DOWN */
+
+    {0x4f, 0},          /* RIGHT_ARROW */
+    {0x50, 0},          /* LEFT_ARROW */
+    {0x51, 0},          /* DOWN_ARROW */
+    {0x52, 0},          /* UP_ARROW */
+};

--- a/src/layouts/PT_PT/hidkeylayout.h
+++ b/src/layouts/PT_PT/hidkeylayout.h
@@ -1,0 +1,177 @@
+#pragma once
+
+enum {
+    UK_LAYOUT,
+    US_LAYOUT
+};
+
+/* Modifiers */
+enum MODIFIER_KEY {
+        KEY_CTRL = 1,
+        KEY_SHIFT = 2,
+        KEY_ALT = 4,
+};
+
+typedef struct {
+        unsigned char usage;
+        unsigned char modifier;
+} KEYMAP;
+
+#define KEYMAP_SIZE (152)
+const KEYMAP keymap[KEYMAP_SIZE] = {
+    {0, 0},             /* NUL */
+    {0, 0},             /* SOH */
+    {0, 0},             /* STX */
+    {0, 0},             /* ETX */
+    {0, 0},             /* EOT */
+    {0, 0},             /* ENQ */
+    {0, 0},             /* ACK */
+    {0, 0},             /* BEL */
+    {0x2a, 0},          /* BS  */  /* Keyboard Delete (Backspace) */
+    {0x2b, 0},          /* TAB */  /* Keyboard Tab */
+    {0x28, 0},          /* LF  */  /* Keyboard Return (Enter) */
+    {0, 0},             /* VT  */
+    {0, 0},             /* FF  */
+    {0, 0},             /* CR  */
+    {0, 0},             /* SO  */
+    {0, 0},             /* SI  */
+    {0, 0},             /* DEL */
+    {0, 0},             /* DC1 */
+    {0, 0},             /* DC2 */
+    {0, 0},             /* DC3 */
+    {0, 0},             /* DC4 */
+    {0, 0},             /* NAK */
+    {0, 0},             /* SYN */
+    {0, 0},             /* ETB */
+    {0, 0},             /* CAN */
+    {0, 0},             /* EM  */
+    {0, 0},             /* SUB */
+    {0, 0},             /* ESC */
+    {0, 0},             /* FS  */
+    {0, 0},             /* GS  */
+    {0, 0},             /* RS  */
+    {0, 0},             /* US  */
+    {0x2c, 0},          /*   */
+    {0x1e, KEY_SHIFT},      /* ! */
+    {0x1f, KEY_SHIFT},      /* " */
+    {0x20, KEY_SHIFT},      /* # */
+    {0x21, KEY_SHIFT},      /* $ */
+    {0x22, KEY_SHIFT},      /* % */
+    {0x23, KEY_SHIFT},      /* & */
+    {0x2d, 0},          /* ' */
+    {0x25, KEY_SHIFT},      /* ( */
+    {0x26, KEY_SHIFT},      /* ) */
+    {0x2f, KEY_SHIFT},      /* * */
+    {0x2f, 0},      /* + */
+    {0x36, 0},          /* , */
+    {0x38, 0},          /* - */
+    {0x37, 0},          /* . */
+    {0x24, KEY_SHIFT},          /* / */
+    {0x27, 0},          /* 0 */
+    {0x1e, 0},          /* 1 */
+    {0x1f, 0},          /* 2 */
+    {0x20, 0},          /* 3 */
+    {0x21, 0},          /* 4 */
+    {0x22, 0},          /* 5 */
+    {0x23, 0},          /* 6 */
+    {0x24, 0},          /* 7 */
+    {0x25, 0},          /* 8 */
+    {0x26, 0},          /* 9 */
+    {0x37, KEY_SHIFT},      /* : */
+    {0x36, KEY_SHIFT},          /* ; */
+    {0x64, 0},      /* < */
+    {0x27, KEY_SHIFT},          /* = */
+    {0x64, KEY_SHIFT},      /* > */
+    {0x2d, KEY_SHIFT},      /* ? */
+    {0x1f, 0},      /* @ */
+    {0x04, KEY_SHIFT},      /* A */
+    {0x05, KEY_SHIFT},      /* B */
+    {0x06, KEY_SHIFT},      /* C */
+    {0x07, KEY_SHIFT},      /* D */
+    {0x08, KEY_SHIFT},      /* E */
+    {0x09, KEY_SHIFT},      /* F */
+    {0x0a, KEY_SHIFT},      /* G */
+    {0x0b, KEY_SHIFT},      /* H */
+    {0x0c, KEY_SHIFT},      /* I */
+    {0x0d, KEY_SHIFT},      /* J */
+    {0x0e, KEY_SHIFT},      /* K */
+    {0x0f, KEY_SHIFT},      /* L */
+    {0x10, KEY_SHIFT},      /* M */
+    {0x11, KEY_SHIFT},      /* N */
+    {0x12, KEY_SHIFT},      /* O */
+    {0x13, KEY_SHIFT},      /* P */
+    {0x14, KEY_SHIFT},      /* Q */
+    {0x15, KEY_SHIFT},      /* R */
+    {0x16, KEY_SHIFT},      /* S */
+    {0x17, KEY_SHIFT},      /* T */
+    {0x18, KEY_SHIFT},      /* U */
+    {0x19, KEY_SHIFT},      /* V */
+    {0x1a, KEY_SHIFT},      /* W */
+    {0x1b, KEY_SHIFT},      /* X */
+    {0x1c, KEY_SHIFT},      /* Y */
+    {0x1d, KEY_SHIFT},      /* Z */
+    {0x25, 0},          /* [ */
+    {0x35, 0},          /* \ */
+    {0x26, 0},          /* ] */
+    {0x31, KEY_SHIFT},      /* ^ */
+    {0x38, KEY_SHIFT},      /* _ */
+    {0x30, KEY_SHIFT},          /* ` */
+    {0x04, 0},          /* a */
+    {0x05, 0},          /* b */
+    {0x06, 0},          /* c */
+    {0x07, 0},          /* d */
+    {0x08, 0},          /* e */
+    {0x09, 0},          /* f */
+    {0x0a, 0},          /* g */
+    {0x0b, 0},          /* h */
+    {0x0c, 0},          /* i */
+    {0x0d, 0},          /* j */
+    {0x0e, 0},          /* k */
+    {0x0f, 0},          /* l */
+    {0x10, 0},          /* m */
+    {0x11, 0},          /* n */
+    {0x12, 0},          /* o */
+    {0x13, 0},          /* p */
+    {0x14, 0},          /* q */
+    {0x15, 0},          /* r */
+    {0x16, 0},          /* s */
+    {0x17, 0},          /* t */
+    {0x18, 0},          /* u */
+    {0x19, 0},          /* v */
+    {0x1a, 0},          /* w */
+    {0x1b, 0},          /* x */
+    {0x1c, 0},          /* y */
+    {0x1d, 0},          /* z */
+    {0x24, 0},      /* { */
+    {0x35, KEY_SHIFT},      /* | */
+    {0x27, 0},      /* } */
+    {0x31, 0},      /* ~ */
+    {0,0},              /* DEL */
+
+    {0x3a, 0},          /* F1 */
+    {0x3b, 0},          /* F2 */
+    {0x3c, 0},          /* F3 */
+    {0x3d, 0},          /* F4 */
+    {0x3e, 0},          /* F5 */
+    {0x3f, 0},          /* F6 */
+    {0x40, 0},          /* F7 */
+    {0x41, 0},          /* F8 */
+    {0x42, 0},          /* F9 */
+    {0x43, 0},          /* F10 */
+    {0x44, 0},          /* F11 */
+    {0x45, 0},          /* F12 */
+
+    {0x46, 0},          /* PRINT_SCREEN */
+    {0x47, 0},          /* SCROLL_LOCK */
+    {0x39, 0},          /* CAPS_LOCK */
+    {0x53, 0},          /* NUM_LOCK */
+    {0x49, 0},          /* INSERT */
+    {0x4a, 0},          /* HOME */
+    {0x4b, 0},          /* PAGE_UP */
+    {0x4e, 0},          /* PAGE_DOWN */
+
+    {0x4f, 0},          /* RIGHT_ARROW */
+    {0x50, 0},          /* LEFT_ARROW */
+    {0x51, 0},          /* DOWN_ARROW */
+    {0x52, 0},          /* UP_ARROW */
+};

--- a/src/layouts/TR_TR/hidkeylayout.h
+++ b/src/layouts/TR_TR/hidkeylayout.h
@@ -1,0 +1,177 @@
+#pragma once
+
+enum {
+    UK_LAYOUT,
+    US_LAYOUT
+};
+
+/* Modifiers */
+enum MODIFIER_KEY {
+        KEY_CTRL = 1,
+        KEY_SHIFT = 2,
+        KEY_ALT = 4,
+};
+
+typedef struct {
+        unsigned char usage;
+        unsigned char modifier;
+} KEYMAP;
+
+#define KEYMAP_SIZE (152)
+const KEYMAP keymap[KEYMAP_SIZE] = {
+    {0, 0},             /* NUL */
+    {0, 0},             /* SOH */
+    {0, 0},             /* STX */
+    {0, 0},             /* ETX */
+    {0, 0},             /* EOT */
+    {0, 0},             /* ENQ */
+    {0, 0},             /* ACK */
+    {0, 0},             /* BEL */
+    {0x2a, 0},          /* BS  */  /* Keyboard Delete (Backspace) */
+    {0x2b, 0},          /* TAB */  /* Keyboard Tab */
+    {0x28, 0},          /* LF  */  /* Keyboard Return (Enter) */
+    {0, 0},             /* VT  */
+    {0, 0},             /* FF  */
+    {0, 0},             /* CR  */
+    {0, 0},             /* SO  */
+    {0, 0},             /* SI  */
+    {0, 0},             /* DEL */
+    {0, 0},             /* DC1 */
+    {0, 0},             /* DC2 */
+    {0, 0},             /* DC3 */
+    {0, 0},             /* DC4 */
+    {0, 0},             /* NAK */
+    {0, 0},             /* SYN */
+    {0, 0},             /* ETB */
+    {0, 0},             /* CAN */
+    {0, 0},             /* EM  */
+    {0, 0},             /* SUB */
+    {0, 0},             /* ESC */
+    {0, 0},             /* FS  */
+    {0, 0},             /* GS  */
+    {0, 0},             /* RS  */
+    {0, 0},             /* US  */
+    {0x2c, 0},          /*   */
+    {0x1e, KEY_SHIFT},      /* ! */
+    {0x35, 0},      /* " */
+    {0x20, KEYBOARD_MODIFIER_RIGHTALT},      /* # */
+    {0x21, KEYBOARD_MODIFIER_RIGHTALT},      /* $ */
+    {0x22, KEY_SHIFT},      /* % */
+    {0x23, KEY_SHIFT},      /* & */
+    {0x1f, KEY_SHIFT},          /* ' */
+    {0x25, KEY_SHIFT},      /* ( */
+    {0x26, KEY_SHIFT},      /* ) */
+    {0x2d, 0},      /* * */
+    {0x21, KEY_SHIFT},      /* + */
+    {0x31, 0},          /* , */
+    {0x2e, 0},          /* - */
+    {0x38, 0},          /* . */
+    {0x24, KEY_SHIFT},          /* / */
+    {0x27, 0},          /* 0 */
+    {0x1e, 0},          /* 1 */
+    {0x1f, 0},          /* 2 */
+    {0x20, 0},          /* 3 */
+    {0x21, 0},          /* 4 */
+    {0x22, 0},          /* 5 */
+    {0x23, 0},          /* 6 */
+    {0x24, 0},          /* 7 */
+    {0x25, 0},          /* 8 */
+    {0x26, 0},          /* 9 */
+    {0x38, KEY_SHIFT},      /* : */
+    {0x31, KEY_SHIFT},          /* ; */
+    {0x64, 0},      /* < */
+    {0x27, KEY_SHIFT},          /* = */
+    {0x64, KEY_SHIFT},      /* > */
+    {0x2d, KEY_SHIFT},      /* ? */
+    {0x14, KEYBOARD_MODIFIER_RIGHTALT},      /* @ */
+    {0x04, KEY_SHIFT},      /* A */
+    {0x05, KEY_SHIFT},      /* B */
+    {0x06, KEY_SHIFT},      /* C */
+    {0x07, KEY_SHIFT},      /* D */
+    {0x08, KEY_SHIFT},      /* E */
+    {0x09, KEY_SHIFT},      /* F */
+    {0x0a, KEY_SHIFT},      /* G */
+    {0x0b, KEY_SHIFT},      /* H */
+    {0x0c, KEY_SHIFT},      /* I */
+    {0x0d, KEY_SHIFT},      /* J */
+    {0x0e, KEY_SHIFT},      /* K */
+    {0x0f, KEY_SHIFT},      /* L */
+    {0x10, KEY_SHIFT},      /* M */
+    {0x11, KEY_SHIFT},      /* N */
+    {0x12, KEY_SHIFT},      /* O */
+    {0x13, KEY_SHIFT},      /* P */
+    {0x14, KEY_SHIFT},      /* Q */
+    {0x15, KEY_SHIFT},      /* R */
+    {0x16, KEY_SHIFT},      /* S */
+    {0x17, KEY_SHIFT},      /* T */
+    {0x18, KEY_SHIFT},      /* U */
+    {0x19, KEY_SHIFT},      /* V */
+    {0x1a, KEY_SHIFT},      /* W */
+    {0x1b, KEY_SHIFT},      /* X */
+    {0x1c, KEY_SHIFT},      /* Y */
+    {0x1d, KEY_SHIFT},      /* Z */
+    {0x25, KEYBOARD_MODIFIER_RIGHTALT},          /* [ */
+    {0x2d, 0},          /* \ */
+    {0x26, KEYBOARD_MODIFIER_RIGHTALT},          /* ] */
+    {0x20, KEY_SHIFT},      /* ^ */
+    {0x2e, KEY_SHIFT},      /* _ */
+    {0x35, KEYBOARD_MODIFIER_RIGHTALT},          /* ` */
+    {0x04, 0},          /* a */
+    {0x05, 0},          /* b */
+    {0x06, 0},          /* c */
+    {0x07, 0},          /* d */
+    {0x08, 0},          /* e */
+    {0x09, 0},          /* f */
+    {0x0a, 0},          /* g */
+    {0x0b, 0},          /* h */
+    {0x0c, 0},          /* i */
+    {0x0d, 0},          /* j */
+    {0x0e, 0},          /* k */
+    {0x0f, 0},          /* l */
+    {0x10, 0},          /* m */
+    {0x11, 0},          /* n */
+    {0x12, 0},          /* o */
+    {0x13, 0},          /* p */
+    {0x14, 0},          /* q */
+    {0x15, 0},          /* r */
+    {0x16, 0},          /* s */
+    {0x17, 0},          /* t */
+    {0x18, 0},          /* u */
+    {0x19, 0},          /* v */
+    {0x1a, 0},          /* w */
+    {0x1b, 0},          /* x */
+    {0x1c, 0},          /* y */
+    {0x1d, 0},          /* z */
+    {0x24, KEYBOARD_MODIFIER_RIGHTALT},      /* { */
+    {0x66, 0},      /* | */
+    {0x27, KEYBOARD_MODIFIER_RIGHTALT},      /* } */
+    {0x30, KEYBOARD_MODIFIER_RIGHTALT},      /* ~ */
+    {0,0},              /* DEL */
+
+    {0x3a, 0},          /* F1 */
+    {0x3b, 0},          /* F2 */
+    {0x3c, 0},          /* F3 */
+    {0x3d, 0},          /* F4 */
+    {0x3e, 0},          /* F5 */
+    {0x3f, 0},          /* F6 */
+    {0x40, 0},          /* F7 */
+    {0x41, 0},          /* F8 */
+    {0x42, 0},          /* F9 */
+    {0x43, 0},          /* F10 */
+    {0x44, 0},          /* F11 */
+    {0x45, 0},          /* F12 */
+
+    {0x46, 0},          /* PRINT_SCREEN */
+    {0x47, 0},          /* SCROLL_LOCK */
+    {0x39, 0},          /* CAPS_LOCK */
+    {0x53, 0},          /* NUM_LOCK */
+    {0x49, 0},          /* INSERT */
+    {0x4a, 0},          /* HOME */
+    {0x4b, 0},          /* PAGE_UP */
+    {0x4e, 0},          /* PAGE_DOWN */
+
+    {0x4f, 0},          /* RIGHT_ARROW */
+    {0x50, 0},          /* LEFT_ARROW */
+    {0x51, 0},          /* DOWN_ARROW */
+    {0x52, 0},          /* UP_ARROW */
+};


### PR DESCRIPTION
Available layouts:

    BE_BE
    DA_DK
    DE_DE
    EN_UK
    EN_US
    ES_ES
    FI_FI
    FR_FR
    IT_IT
    PT_BR
    PT_PT
    TR_TR

Replace hidkeylayout.h of the EspTinyUSB library with the hidkeylayout.h file of the new layout or implement all layouts inside hidkeylayout.h (EspTinyUSB library).

Not all layouts tested, there may be some errors here, but this is easy to fix